### PR TITLE
cherry-pick 2 commits to bring main branch up to date with Verus changes

### DIFF
--- a/deps_hack/rust-toolchain.toml
+++ b/deps_hack/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.79"
+channel = "1.82.0"

--- a/storage_node/rust-toolchain.toml
+++ b/storage_node/rust-toolchain.toml
@@ -1,2 +1,7 @@
+# We have to use 1.82.0 to be compatible with Verus.
+# (We used to need a nightly release to use the
+# unstable feature `new_uninit`, but that's a stable
+# feature in 1.82.0.)
+
 [toolchain]
-channel = "1.76"
+channel = "1.82.0"

--- a/storage_node/src/lib.rs
+++ b/storage_node/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(maybe_uninit_as_bytes)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_write_slice)]
-#![feature(new_uninit)]
 #![allow(unused_imports)]
 
 use builtin::*;

--- a/storage_node/src/log/logimpl_v.rs
+++ b/storage_node/src/log/logimpl_v.rs
@@ -661,9 +661,9 @@ verus! {
             where
                 PMRegion: PersistentMemoryRegion,
             requires
-                subregion.inv(old::<&mut _>(wrpm_region), perm),
+                subregion.inv(old(wrpm_region), perm),
                 subregion.len() == LogMetadata::spec_size_of() + u64::spec_size_of(),
-                subregion.view(old::<&mut _>(wrpm_region)).no_outstanding_writes(),
+                subregion.view(old(wrpm_region)).no_outstanding_writes(),
                 forall |addr: int| #[trigger] subregion.is_writable_absolute_addr_fn()(addr),
             ensures
                 subregion.inv(wrpm_region, perm),

--- a/storage_node/src/pmem/pmemspec_t.rs
+++ b/storage_node/src/pmem/pmemspec_t.rs
@@ -43,21 +43,6 @@ use deps_hack::crc64fast::Digest;
 
 verus! {
 
-    // map_err
-    #[verifier::external_fn_specification]
-    pub fn map_err<T, E, F, O: FnOnce(E) -> F>(result: Result<T, E>, op: O) -> (mapped_result: Result<T, F>)
-        requires 
-            result.is_err() ==> op.requires((result.get_Err_0(),)), 
-        ensures 
-            result.is_err() ==> mapped_result.is_err() && op.ensures(
-                (result.get_Err_0(),),
-                mapped_result.get_Err_0(),
-            ),
-            result.is_ok() ==> mapped_result == Result::<T, F>::Ok(result.get_Ok_0()),
-    {
-        result.map_err(op)
-    }
-
     // This function is used to copy bytes from a slice to a newly-allocated vector.
     // `std::slice::copy_from_slice` requires that the source and destination have the
     // same length, so this function allocates a buffer with the correct length, 

--- a/storage_node/src/pmem/subregion_v.rs
+++ b/storage_node/src/pmem/subregion_v.rs
@@ -538,14 +538,14 @@ impl WriteRestrictedPersistentMemorySubregion
             Perm: CheckPermission<Seq<u8>>,
             PMRegion: PersistentMemoryRegion,
         requires
-            self.inv(old::<&mut _>(wrpm), perm),
-            relative_addr + bytes@.len() <= self.view(old::<&mut _>(wrpm)).len(),
-            self.view(old::<&mut _>(wrpm)).no_outstanding_writes_in_range(relative_addr as int,
+            self.inv(old(wrpm), perm),
+            relative_addr + bytes@.len() <= self.view(old(wrpm)).len(),
+            self.view(old(wrpm)).no_outstanding_writes_in_range(relative_addr as int,
                                                                         relative_addr + bytes.len()),
             forall |i: int| relative_addr <= i < relative_addr + bytes@.len() ==> self.is_writable_relative_addr(i),
         ensures
             self.inv(wrpm, perm),
-            self.view(wrpm) == self.view(old::<&mut _>(wrpm)).write(relative_addr as int, bytes@),
+            self.view(wrpm) == self.view(old(wrpm)).write(relative_addr as int, bytes@),
     {
         let ghost subregion_view = self.view(wrpm).write(relative_addr as int, bytes@);
         assert(forall |addr| #![trigger self.is_writable_absolute_addr_fn()(addr)]
@@ -583,10 +583,10 @@ impl WriteRestrictedPersistentMemorySubregion
             Perm: CheckPermission<Seq<u8>>,
             PMRegion: PersistentMemoryRegion,
         requires
-            self.inv(old::<&mut _>(wrpm), perm),
+            self.inv(old(wrpm), perm),
             self.start() <= absolute_addr,
             absolute_addr + bytes@.len() <= self.len(),
-            self.view(old::<&mut _>(wrpm)).no_outstanding_writes_in_range(
+            self.view(old(wrpm)).no_outstanding_writes_in_range(
                 absolute_addr - self.start(),
                 absolute_addr + bytes@.len() - self.start()
             ),
@@ -594,7 +594,7 @@ impl WriteRestrictedPersistentMemorySubregion
                 #[trigger] self.is_writable_absolute_addr_fn()(i),
         ensures
             self.inv(wrpm, perm),
-            self.view(wrpm) == self.view(old::<&mut _>(wrpm)).write(absolute_addr - self.start(), bytes@),
+            self.view(wrpm) == self.view(old(wrpm)).write(absolute_addr - self.start(), bytes@),
     {
         let ghost subregion_view = self.view(wrpm).write(absolute_addr - self.start(), bytes@);
         assert forall |i| #![trigger wrpm@.state[i]]
@@ -618,15 +618,15 @@ impl WriteRestrictedPersistentMemorySubregion
             Perm: CheckPermission<Seq<u8>>,
             PMRegion: PersistentMemoryRegion,
         requires
-            self.inv(old::<&mut _>(wrpm), perm),
-            relative_addr + S::spec_size_of() <= self.view(old::<&mut _>(wrpm)).len(),
-            self.view(old::<&mut _>(wrpm)).no_outstanding_writes_in_range(relative_addr as int,
+            self.inv(old(wrpm), perm),
+            relative_addr + S::spec_size_of() <= self.view(old(wrpm)).len(),
+            self.view(old(wrpm)).no_outstanding_writes_in_range(relative_addr as int,
                                                                         relative_addr + S::spec_size_of()),
             forall |i: int| relative_addr <= i < relative_addr + S::spec_size_of() ==>
                 self.is_writable_relative_addr(i),
         ensures
             self.inv(wrpm, perm),
-            self.view(wrpm) == self.view(old::<&mut _>(wrpm)).write(relative_addr as int, to_write.spec_to_bytes()),
+            self.view(wrpm) == self.view(old(wrpm)).write(relative_addr as int, to_write.spec_to_bytes()),
     {
         let ghost bytes = to_write.spec_to_bytes();
         assert(bytes.len() == S::spec_size_of());
@@ -667,10 +667,10 @@ impl WriteRestrictedPersistentMemorySubregion
             Perm: CheckPermission<Seq<u8>>,
             PMRegion: PersistentMemoryRegion,
         requires
-            self.inv(old::<&mut _>(wrpm), perm),
+            self.inv(old(wrpm), perm),
             self.start() <= absolute_addr,
             absolute_addr + S::spec_size_of() <= self.len(),
-            self.view(old::<&mut _>(wrpm)).no_outstanding_writes_in_range(
+            self.view(old(wrpm)).no_outstanding_writes_in_range(
                 absolute_addr - self.start(),
                 absolute_addr + S::spec_size_of() - self.start()
             ),
@@ -678,7 +678,7 @@ impl WriteRestrictedPersistentMemorySubregion
                 #[trigger] self.is_writable_absolute_addr_fn()(i),
         ensures
             self.inv(wrpm, perm),
-            self.view(wrpm) == self.view(old::<&mut _>(wrpm)).write(absolute_addr - self.start(),
+            self.view(wrpm) == self.view(old(wrpm)).write(absolute_addr - self.start(),
                                                                   to_write.spec_to_bytes()),
     {
         let ghost bytes = to_write.spec_to_bytes();
@@ -1279,14 +1279,14 @@ impl WritablePersistentMemorySubregion
         bytes: &[u8],
     )
         requires
-            self.inv(old::<&mut _>(pm)),
-            relative_addr + bytes@.len() <= self.view(old::<&mut _>(pm)).len(),
-            self.view(old::<&mut _>(pm)).no_outstanding_writes_in_range(relative_addr as int,
+            self.inv(old(pm)),
+            relative_addr + bytes@.len() <= self.view(old(pm)).len(),
+            self.view(old(pm)).no_outstanding_writes_in_range(relative_addr as int,
                                                                       relative_addr + bytes.len()),
             forall |i: int| relative_addr <= i < relative_addr + bytes@.len() ==> self.is_writable_relative_addr(i),
         ensures
             self.inv(pm),
-            self.view(pm) == self.view(old::<&mut _>(pm)).write(relative_addr as int, bytes@),
+            self.view(pm) == self.view(old(pm)).write(relative_addr as int, bytes@),
     {
         let ghost subregion_view = self.view(pm).write(relative_addr as int, bytes@);
         assert(forall |addr| #![trigger self.is_writable_absolute_addr_fn()(addr)]
@@ -1307,10 +1307,10 @@ impl WritablePersistentMemorySubregion
         bytes: &[u8],
     )
         requires
-            self.inv(old::<&mut _>(pm)),
+            self.inv(old(pm)),
             self.start() <= absolute_addr,
             absolute_addr + bytes@.len() <= self.len(),
-            self.view(old::<&mut _>(pm)).no_outstanding_writes_in_range(
+            self.view(old(pm)).no_outstanding_writes_in_range(
                 absolute_addr - self.start(),
                 absolute_addr + bytes@.len() - self.start()
             ),
@@ -1318,7 +1318,7 @@ impl WritablePersistentMemorySubregion
                 #[trigger] self.is_writable_absolute_addr_fn()(i),
         ensures
             self.inv(pm),
-            self.view(pm) == self.view(old::<&mut _>(pm)).write(absolute_addr - self.start(), bytes@),
+            self.view(pm) == self.view(old(pm)).write(absolute_addr - self.start(), bytes@),
     {
         let ghost subregion_view = self.view(pm).write(absolute_addr - self.start(), bytes@);
         assert forall |i| #![trigger pm@.state[i]]
@@ -1340,15 +1340,15 @@ impl WritablePersistentMemorySubregion
             S: PmCopy + Sized,
             PMRegion: PersistentMemoryRegion,
         requires
-            self.inv(old::<&mut _>(pm)),
-            relative_addr + S::spec_size_of() <= self.view(old::<&mut _>(pm)).len(),
-            self.view(old::<&mut _>(pm)).no_outstanding_writes_in_range(relative_addr as int,
+            self.inv(old(pm)),
+            relative_addr + S::spec_size_of() <= self.view(old(pm)).len(),
+            self.view(old(pm)).no_outstanding_writes_in_range(relative_addr as int,
                                                                         relative_addr + S::spec_size_of()),
             forall |i: int| relative_addr <= i < relative_addr + S::spec_size_of() ==>
                 self.is_writable_relative_addr(i),
         ensures
             self.inv(pm),
-            self.view(pm) == self.view(old::<&mut _>(pm)).write(relative_addr as int, to_write.spec_to_bytes()),
+            self.view(pm) == self.view(old(pm)).write(relative_addr as int, to_write.spec_to_bytes()),
     {
         let ghost bytes = to_write.spec_to_bytes();
         assert(bytes.len() == S::spec_size_of());
@@ -1374,10 +1374,10 @@ impl WritablePersistentMemorySubregion
             S: PmCopy + Sized,
             PMRegion: PersistentMemoryRegion,
         requires
-            self.inv(old::<&mut _>(pm)),
+            self.inv(old(pm)),
             self.start() <= absolute_addr,
             absolute_addr + S::spec_size_of() <= self.len(),
-            self.view(old::<&mut _>(pm)).no_outstanding_writes_in_range(
+            self.view(old(pm)).no_outstanding_writes_in_range(
                 absolute_addr - self.start(),
                 absolute_addr + S::spec_size_of() - self.start()
             ),
@@ -1385,7 +1385,7 @@ impl WritablePersistentMemorySubregion
                 #[trigger] self.is_writable_absolute_addr_fn()(i),
         ensures
             self.inv(pm),
-            self.view(pm) == self.view(old::<&mut _>(pm)).write(absolute_addr - self.start(),
+            self.view(pm) == self.view(old(pm)).write(absolute_addr - self.start(),
                                                               to_write.spec_to_bytes()),
     {
         let ghost bytes = to_write.spec_to_bytes();


### PR DESCRIPTION
This cherry-picks 7d3496c and 64e9faf to bring the main branch up to date with the latest changes in Verus, so that the veritas test ( https://github.com/verus-lang/verus/tree/main/tools/veritas ) passes again.