### PR TITLE
fix Verus errors

### DIFF
--- a/storage_node/src/journal/entry_v.rs
+++ b/storage_node/src/journal/entry_v.rs
@@ -138,7 +138,7 @@ pub(super) open spec fn journaled_addrs_complete(entries: Seq<JournalEntry>, jou
         entries.contains(entry) && entry.start <= addr < entry.end() ==> journaled_addrs.contains(addr)
 }
 
-pub(super) struct ConcreteJournalEntry
+pub struct ConcreteJournalEntry
 {
     pub start: u64,
     pub bytes_to_write: Vec<u8>,
@@ -175,7 +175,7 @@ impl ConcreteJournalEntry
     }
 }
 
-pub(super) struct ConcreteJournalEntries
+pub struct ConcreteJournalEntries
 {
     pub entries: Vec<ConcreteJournalEntry>,
 }

--- a/storage_node/src/kv2/keys/inv_v.rs
+++ b/storage_node/src/kv2/keys/inv_v.rs
@@ -67,7 +67,7 @@ impl<K> KeyRowDisposition<K>
 
 #[verifier::reject_recursive_types(K)]
 #[verifier::ext_equal]
-pub(super) struct KeyMemoryMapping<K> {
+pub struct KeyMemoryMapping<K> {
     pub row_info: Map<u64, KeyRowDisposition<K>>,
     pub key_info: Map<K, u64>,
     pub item_info: Map<u64, u64>,


### PR DESCRIPTION
The latest version of Verus gave errors like these:

```
error: disallowed: field expression for a non-visible datatype
   --> kv2/keys/inv_v.rs:212:33
    |
70  | / pub(super) struct KeyMemoryMapping<K> {
71  | |     pub row_info: Map<u64, KeyRowDisposition<K>>,
72  | |     pub key_info: Map<K, u64>,
73  | |     pub item_info: Map<u64, u64>,
74  | |     pub list_info: Map<u64, u64>,
75  | | }
    | |_- this datatype is only visible to `lib::kv2::keys`
...
212 |                   |row_addr: u64| self.row_info.contains_key(row_addr),
    |                                   ^^^^^^^^^^^^^ this field expression is disallowed because of non-visibility
    |
    = help: note that because this is a pub open spec function, this field expression must be well-formed everywhere, which is wider than `lib::kv2::keys`
```

Another potential fix would be to change the `pub open spec fn` definitions into `pub(super) open spec fn`, but that doesn't work for `view()` where the `pub` is mandated by the `View` trait, and cannot be turned into `put(super)`.