### PR TITLE
Fix building capybarakv on Linux without PMDK

### DIFF
--- a/osdi25/capybaraKV/capybarakv/Cargo.toml
+++ b/osdi25/capybaraKV/capybarakv/Cargo.toml
@@ -20,7 +20,7 @@ default = [ "pmem" ]
 builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
 builtin = { git = "https://github.com/verus-lang/verus.git" }
 vstd = { git = "https://github.com/verus-lang/verus.git" }
-deps_hack = { path = "../deps_hack" }
+deps_hack = { path = "../deps_hack", default-features = false }
 pmcopy = { path = "../pmcopy" }
 
 [lints.rust]


### PR DESCRIPTION
Building on Linux without PMDK requires disabling the "pmem" feature in deps_hack, which requires using "default-features = false" for that dependency.  The capybarakv "pmem" feature (enabled by default) does explicitly enable the deps_hack "pmem" feature, so everything still works the same by default (requiring PMDK), but now "cargo build --no-default-features" and "cargo test --no-default-features" in capybarakv work even if PMDK is not installed.