### PR TITLE
change agree() to be a proof fn

### DIFF
--- a/osdi25/capybaraKV/capybarakv/src/journal/impl_v.rs
+++ b/osdi25/capybaraKV/capybarakv/src/journal/impl_v.rs
@@ -77,9 +77,7 @@ where
         &&& seqs_match_in_range(j1.state, j2.state, j1.constants.app_area_start as int, j1.constants.app_area_end as int)
     }
 
-    #[inline(always)]
-    #[verifier::atomic]
-    pub exec fn agree(&self, Tracked(r): Tracked<&GhostVar<Seq<u8>>>)
+    pub proof fn agree(tracked &self, tracked r: &GhostVar<Seq<u8>>)
         requires
             self.valid(),
             self@.powerpm_id == r.id(),
@@ -87,9 +85,8 @@ where
             self@.durable_state == r@,
         opens_invariants
             none
-        no_unwind
     {
-        self.powerpm.agree(Tracked(r));
+        self.powerpm.agree(r);
     }
 
     pub exec fn remaining_capacity(&self) -> (result: u64)

--- a/osdi25/capybaraKV/capybarakv/src/kv2/commit_v.rs
+++ b/osdi25/capybaraKV/capybarakv/src/kv2/commit_v.rs
@@ -80,9 +80,7 @@ where
         Ok(complete)
     }
 
-    #[inline(always)]
-    #[verifier::atomic]
-    pub exec fn agree(&self, Tracked(r): Tracked<&GhostVar<Seq<u8>>>)
+    pub proof fn agree(tracked &self, tracked r: &GhostVar<Seq<u8>>)
         requires
             self.valid(),
             r.id() == self@.powerpm_id,
@@ -90,13 +88,9 @@ where
             Self::recover(r@) == Some(RecoveredKvStore::<K, I, L>{ ps: self@.ps, kv: self@.durable })
         opens_invariants
             none
-        no_unwind
     {
-        self.journal.agree(Tracked(r));
-
-        proof {
-            self.lemma_recover_to_durable_state();
-        }
+        self.journal.agree(r);
+        self.lemma_recover_to_durable_state();
     }
 }
 

--- a/osdi25/capybaraKV/capybarakv/src/kv2/rwkv_v.rs
+++ b/osdi25/capybaraKV/capybarakv/src/kv2/rwkv_v.rs
@@ -185,9 +185,8 @@ exec fn maybe_commit<PM, K, I, L, Op, CB>(
             let ghost ckv = ConcurrentKvStoreView::<K, I, L>::from_kvstore_view(kv_internal.kv@);
 
             open_atomic_invariant!(inv.borrow() => inner => {
-                kv_internal.kv.agree(Tracked(&inner.durable_res));
-
                 proof {
+                    kv_internal.kv.agree(&inner.durable_res);
                     inner.rwlock_auth.agree(kv_internal.invariant_resource.borrow());
 
                     // We can provably unwrap, because if it was None, that means
@@ -752,9 +751,8 @@ where
         let tracked mut rwlock_res = rwlock_res;
 
         open_atomic_invariant!(&inv => inner => {
-            atomicpm.agree(Tracked(&inner.durable_res));
-
             proof {
+                atomicpm.agree(&inner.durable_res);
                 inner.rwlock_auth.update(&mut rwlock_res, inner.caller_auth@);
             }
         });

--- a/osdi25/capybaraKV/capybarakv/src/pmem/power_t.rs
+++ b/osdi25/capybaraKV/capybarakv/src/pmem/power_t.rs
@@ -59,9 +59,7 @@ impl<PM: PersistentMemoryRegion> PersistentMemoryRegionAtomic<PM> {
         self.pm.constants()
     }
 
-    #[inline(always)]
-    #[verifier::atomic]
-    pub exec fn agree(&self, Tracked(r): Tracked<&GhostVar<Seq<u8>>>)
+    pub proof fn agree(tracked &self, tracked r: &GhostVar<Seq<u8>>)
         requires
             self.inv(),
             self.id() == r.id(),
@@ -69,11 +67,8 @@ impl<PM: PersistentMemoryRegion> PersistentMemoryRegionAtomic<PM> {
             self@.durable_state == r@,
         opens_invariants
             none
-        no_unwind
     {
-        proof {
-            self.res.borrow().agree(r);
-        }
+        self.res.borrow().agree(r);
     }
 
     pub exec fn new(pm: PM) -> (result: (Self, Tracked<GhostVar<Seq<u8>>>))

--- a/osdi25/capybaraKV/capybarakv/src/pmem/power_v.rs
+++ b/osdi25/capybaraKV/capybarakv/src/pmem/power_v.rs
@@ -200,9 +200,7 @@ impl<PMRegion> PoWERPersistentMemoryRegion<PMRegion>
         self.pm_region.pm.lemma_inv_implies_view_valid();
     }
 
-    #[inline(always)]
-    #[verifier::atomic]
-    pub exec fn agree(&self, Tracked(r): Tracked<&GhostVar<Seq<u8>>>)
+    pub proof fn agree(tracked &self, tracked r: &GhostVar<Seq<u8>>)
         requires
             self.inv(),
             self.id() == r.id(),
@@ -210,9 +208,8 @@ impl<PMRegion> PoWERPersistentMemoryRegion<PMRegion>
             self@.durable_state == r@,
         opens_invariants
             none
-        no_unwind
     {
-        self.pm_region.agree(Tracked(r));
+        self.pm_region.agree(r);
     }
 
     pub exec fn new(pm_region: PMRegion) -> (result: (Self, Tracked<GhostVar<Seq<u8>>>))


### PR DESCRIPTION
The original reason why this was an `exec fn` was that we needed a tracked self, to eventually get a tracked ghost variable from it.  But turns out Verus is OK with turning an exec-mode variable into a tracked variable, so this change works just fine.