### PR TITLE
Updates for `cargo verus`

### DIFF
--- a/capybaraKV/README.md
+++ b/capybaraKV/README.md
@@ -22,15 +22,16 @@ repo in the `osdi25-artifact` branch.
 
 ### Verification
 
-To verify CapybaraKV, make sure Verus (usually at `verus/source/target-verus/release`) is in your path and run one of the following, depending on your setup:
-1. If you are using MacOS, Windows, or Linux/WSL with the dependencies from Setup Step 3 installed, run `cargo verus verify`.
-2. Otherwise (i.e., Linux/WSL without PM dependencies), run `cargo verus verify --no-default-features`.
+To verify CapybaraKV:
+1. Make sure Verus (usually at `verus/source/target-verus/release`) is in your `PATH`.
+2. From the top-level directory of this repository, `cd` to `capybaraKV/capybarakv`.
+3. Run one of the following commands depending on your setup:
+    1. If you are using MacOS, Windows, or Linux/WSL with the dependencies from Setup Step 3 installed, run `cargo verus verify`.
+    2. Otherwise (i.e., Linux/WSL without PM dependencies), run `cargo verus verify --no-default-features`.
 
 ### Compiling for execution
 
-If you are using Linux/WSL with the dependencies from Setup Step 3, MacOS, or Windows: build with `cargo build`.
-
-Otherwise: build with `cargo build --no-default-features`.
+From the top-level directory of this repository, `cd` to `capybaraKV/capybarakv`. If you are using Linux/WSL with the dependencies from Setup Step 3, MacOS, or Windows: build with `cargo build`. Otherwise: build with `cargo build --no-default-features`.
 
 ### Computing code size
 

--- a/capybaraKV/README.md
+++ b/capybaraKV/README.md
@@ -23,12 +23,14 @@ repo in the `osdi25-artifact` branch.
 ### Verification
 
 To verify CapybaraKV, make sure Verus (usually at `verus/source/target-verus/release`) is in your path and run one of the following, depending on your setup:
-1. If you are on Linux/WSL and installed the optional dependencies in step 3 above, run: `cargo verus verify`
-2. Otherwise, run: `cargo verus verify --no-default-features`
+1. If you are using MacOS, Windows, or Linux/WSL with the dependencies from Setup Step 3 installed, run `cargo verus verify`.
+2. Otherwise (i.e., Linux/WSL without PM dependencies), run `cargo verus verify --no-default-features`.
 
 ### Compiling for execution
 
-CapybaraKV can be built using `cargo build --no-default-features`. Exclude `--no-default-features` if you installed the dependencies in Setup Step 3 and would like to use real/emulated PM.
+If you are using Linux/WSL with the dependencies from Setup Step 3, MacOS, or Windows: build with `cargo build`.
+
+Otherwise: build with `cargo build --no-default-features`.
 
 ### Computing code size
 
@@ -37,7 +39,7 @@ We provide a python script, `count_capybarakv_lines.py`, that uses this tool to 
 The script also uses `tokei` (https://github.com/XAMPPRocky/tokei, installed in the setup instructions above) to count the lines of code in the `pmcopy` crate, which is implemented in regular Rust.
 
 To use the script, run the following commands. These differ from the standard verification instructions because `cargo verus` does not currently support the required options.
-1. `cd deps_hack` and run `cargo build --no-default-features`. Omit `--no-default-features` if you installed the dependencies in Setup Step 3. 
+1. `cd deps_hack` and run `cargo build`. Include `--no-default-features` if on Linux/WSL without PM dependencies installed.
 2. Run the following:
     ```bash
     cd ../capybarakv/src

--- a/capybaraKV/capybarakv/Cargo.toml
+++ b/capybaraKV/capybarakv/Cargo.toml
@@ -17,8 +17,8 @@ default = [ "pmem" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
-builtin = { git = "https://github.com/verus-lang/verus.git" }
+verus_builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
+verus_builtin = { git = "https://github.com/verus-lang/verus.git" }
 vstd = { git = "https://github.com/verus-lang/verus.git" }
 deps_hack = { path = "../deps_hack", default-features = false }
 pmcopy = { path = "../pmcopy" }

--- a/capybaraKV/capybarakv/src/count_capybarakv_lines.py
+++ b/capybaraKV/capybarakv/src/count_capybarakv_lines.py
@@ -71,8 +71,6 @@ def count_lines(line_count_file):
 
 def count_pmcopy_lines(pmcopy_directory):
     # pmcopy is in a separate crate so we'll handle it separately
-    # TODO: tokei install instructions or use a different tool
-    # TODO: change name of the crate
     output = subprocess.check_output(["tokei", pmcopy_directory, "--output", "json"])
     output_dict = json.loads(output)
     return output_dict["Rust"]["code"]

--- a/capybaraKV/capybarakv/src/kv2/util_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/util_v.rs
@@ -235,7 +235,7 @@ where
                Some(RecoveredKvStore::<K, I, L>{ ps: self@.ps, kv: self@.durable }));
     }
 
-    pub(super) proof fn lemma_prepare_for_key_table_update(&self) -> (result: Self)
+    pub(super) proof fn lemma_prepare_for_key_table_update(self) -> (result: Self)
         requires
             self.inv(),
             self.status@ is ComponentsDontCorrespond,
@@ -281,7 +281,7 @@ where
             assert(Self::recover(s2) =~= Some(RecoveredKvStore::<K, I, L>{ ps: self@.ps, kv: self@.durable }));
         }
 
-        *self
+        self
     }
 
     pub(super) proof fn lemma_reflect_key_table_update(self, old_self: Self)
@@ -319,7 +319,7 @@ where
         self.lemma_recover_static_metadata_depends_only_on_my_area(old_self.journal@, self.journal@);
     }
 
-    pub(super) proof fn lemma_prepare_for_item_table_update(&self) -> (result: Self)
+    pub(super) proof fn lemma_prepare_for_item_table_update(self) -> (result: Self)
         requires
             self.inv(),
             self.status@ is ComponentsDontCorrespond,
@@ -367,7 +367,7 @@ where
             assert(Self::recover(s2) =~= Some(RecoveredKvStore::<K, I, L>{ ps: self@.ps, kv: self@.durable }));
         }
 
-        *self
+        self
     }
 
     pub(super) proof fn lemma_reflect_item_table_update(self, old_self: Self)
@@ -405,7 +405,7 @@ where
         self.lemma_recover_static_metadata_depends_only_on_my_area(old_self.journal@, self.journal@);
     }
 
-    pub(super) proof fn lemma_prepare_for_list_table_update(&self) -> (result: Self)
+    pub(super) proof fn lemma_prepare_for_list_table_update(self) -> (result: Self)
         requires
             self.inv(),
             self.status@ is ComponentsDontCorrespond,
@@ -453,7 +453,7 @@ where
             assert(Self::recover(s2) =~= Some(RecoveredKvStore::<K, I, L>{ ps: self@.ps, kv: self@.durable }));
         }
 
-        *self
+        self
     }
 
     pub(super) proof fn lemma_reflect_list_table_update(self, old_self: Self)

--- a/capybaraKV/capybarakv/src/pmem/mod.rs
+++ b/capybaraKV/capybarakv/src/pmem/mod.rs
@@ -2,7 +2,7 @@
 pub mod linux_pmemfile_t;
 #[cfg(target_os = "windows")]
 pub mod windows_pmemfile_t;
-#[cfg(target_family = "unix")]
+#[cfg(any(target_os = "macos", all(target_os = "linux", not(feature = "pmem"))))]
 pub mod mmap_pmemfile_t;
 
 pub mod crashinv_t;

--- a/multilog/README.md
+++ b/multilog/README.md
@@ -25,18 +25,15 @@ have gotten corrupted on that memory.
 
 ### Setup instructions
 
-Install Verus from `https://github.com/verus-lang/verus`.
+1. Install Verus from `https://github.com/verus-lang/verus`.
+2. **Optional**: If you are on Linux or WSL2 and would like to run CapybaraKV on (real or emulated) PM via Linux's DAX feature, run the following to install PMDK to access PM and LLVM/Clang to generate Rust bindings to PMDK: `sudo apt install libpmem1 libpmemlog1 libpmem-dev libpmemlog-dev llvm-dev clang libclang-dev`
+
 
 ### Verification
 
-To verify the multilog, run the following.
-
-```
-cd deps_hack
-cargo build
-cd ../multilog/src
-verus lib.rs --compile --expand-errors -L dependency=../../deps_hack/target/debug/deps --extern=deps_hack=../../deps_hack/target/debug/libdeps_hack.rlib
-```
+To verify the multilog, make sure Verus (usually at `verus/source/target-verus/release`) is in your path and run one of the following, depending on your setup:
+1. If you are using  Linux/WSL with the dependencies from Setup Step 2 installed, MacOS, or Windows: run `cargo verus verify`.
+2. Otherwise (i.e., Linux/WSL without PM dependencies): run `cargo verus verify --no-default-features`.
 
 Note that the `--compile` flag above is necessary to perform some non-Verus compile time checks that are part of the verification process. 
 Specifically, it checks compile-time assertions, which help check that we use the correct size for structures in proofs, are run by the Rust compiler, not by Verus.

--- a/multilog/README.md
+++ b/multilog/README.md
@@ -31,9 +31,12 @@ have gotten corrupted on that memory.
 
 ### Verification
 
-To verify the multilog, make sure Verus (usually at `verus/source/target-verus/release`) is in your path and run one of the following, depending on your setup:
-1. If you are using  Linux/WSL with the dependencies from Setup Step 2 installed, MacOS, or Windows: run `cargo verus verify`.
-2. Otherwise (i.e., Linux/WSL without PM dependencies): run `cargo verus verify --no-default-features`.
+To verify the multilog:
+1. Make sure Verus (usually at `verus/source/target-verus/release`) is in your `PATH`.
+2. From the top-level directory of this repository, `cd` to `multilog/multilog`.
+3. Run one of the following commands depending on your setup:
+    1. If you are using  Linux/WSL with the dependencies from Setup Step 2 installed, MacOS, or Windows: run `cargo verus verify`.
+    2. Otherwise (i.e., Linux/WSL without PM dependencies): run `cargo verus verify --no-default-features`.
 
 Note that the `--compile` flag above is necessary to perform some non-Verus compile time checks that are part of the verification process. 
 Specifically, it checks compile-time assertions, which help check that we use the correct size for structures in proofs, are run by the Rust compiler, not by Verus.

--- a/multilog/multilog/Cargo.toml
+++ b/multilog/multilog/Cargo.toml
@@ -17,8 +17,8 @@ default = [ "pmem" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
-builtin = { git = "https://github.com/verus-lang/verus.git" }
+verus_builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
+verus_builtin = { git = "https://github.com/verus-lang/verus.git" }
 vstd = { git = "https://github.com/verus-lang/verus.git" }
 deps_hack = { path = "../deps_hack", default-features = false }
 pmsafe = { path = "../pmsafe" }

--- a/multilog/multilog/Cargo.toml
+++ b/multilog/multilog/Cargo.toml
@@ -3,13 +3,24 @@ name = "multilog"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+## The "pmem" feature enables actual persistent memory libraries, such as
+## PMDK on Linux.  Not enabling this feature is helpful when testing with
+## memory-mapped files that are not backed by PMDK.  This feature enables
+## the "pmem" feature in deps_hack, which links in PMDK.
+pmem = [ "deps_hack/pmem" ]
+
+## The "pmem" feature is enabled by default, but can be disabled; e.g.,
+## to run tests without PMDK, run `cargo test --no-default-features`.
+default = [ "pmem" ]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
 builtin = { git = "https://github.com/verus-lang/verus.git" }
 vstd = { git = "https://github.com/verus-lang/verus.git" }
-deps_hack = { path = "../deps_hack", default-features = true }
+deps_hack = { path = "../deps_hack", default-features = false }
 pmsafe = { path = "../pmsafe" }
 
 [lints.rust]

--- a/multilog/multilog/src/lib.rs
+++ b/multilog/multilog/src/lib.rs
@@ -13,11 +13,11 @@ use crate::multilog::layout_v::*;
 use crate::multilog::multilogimpl_t::*;
 use crate::multilog::multilogimpl_v::*;
 use crate::multilog::multilogspec_t::*;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "pmem"))]
 use crate::pmem::linux_pmemfile_t::*;
 #[cfg(target_os = "windows")]
 use crate::pmem::windows_pmemfile_t::*;
-#[cfg(target_os = "macos")]
+#[cfg(target_family = "unix")]
 use crate::pmem::mmap_pmemfile_t::*;
 use crate::pmem::pmemmock_t::*;
 use crate::pmem::pmemspec_t::*;
@@ -121,13 +121,13 @@ fn test_multilog_on_memory_mapped_file() -> Option<()>
         region_sizes.as_slice(),
         FileCloseBehavior::TestingSoDeleteOnClose
     ).ok()?;
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "pmem"))]
     let mut pm_regions = FileBackedPersistentMemoryRegions::new(
         &file_name,
         region_sizes.as_slice(),
         PersistentMemoryCheck::DontCheckForPersistentMemory,
     ).ok()?;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", not(feature = "pmem")))]
     let mut pm_regions = FileBackedPersistentMemoryRegions::new(
         &file_name,
         region_sizes.as_slice(),

--- a/multilog/multilog/src/lib.rs
+++ b/multilog/multilog/src/lib.rs
@@ -17,7 +17,7 @@ use crate::multilog::multilogspec_t::*;
 use crate::pmem::linux_pmemfile_t::*;
 #[cfg(target_os = "windows")]
 use crate::pmem::windows_pmemfile_t::*;
-#[cfg(target_family = "unix")]
+#[cfg(any(target_os = "macos", all(target_os = "linux", not(feature = "pmem"))))]
 use crate::pmem::mmap_pmemfile_t::*;
 use crate::pmem::pmemmock_t::*;
 use crate::pmem::pmemspec_t::*;

--- a/multilog/multilog/src/pmem/mod.rs
+++ b/multilog/multilog/src/pmem/mod.rs
@@ -2,7 +2,7 @@
 pub mod linux_pmemfile_t;
 #[cfg(target_os = "windows")]
 pub mod windows_pmemfile_t;
-#[cfg(target_family = "unix")]
+#[cfg(any(target_os = "macos", all(target_os = "linux", not(feature = "pmem"))))]
 pub mod mmap_pmemfile_t;
 pub mod pmemmock_t;
 pub mod pmemspec_t;

--- a/multilog/multilog/src/pmem/mod.rs
+++ b/multilog/multilog/src/pmem/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "pmem"))]
 pub mod linux_pmemfile_t;
 #[cfg(target_os = "windows")]
 pub mod windows_pmemfile_t;

--- a/pmemlog/Cargo.toml
+++ b/pmemlog/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
-builtin = { git = "https://github.com/verus-lang/verus.git" }
+verus_builtin_macros = { git = "https://github.com/verus-lang/verus.git" }
+verus_builtin = { git = "https://github.com/verus-lang/verus.git" }
 vstd = { git = "https://github.com/verus-lang/verus.git" }
 crc64fast = "1.0.0"
 

--- a/pmemlog/Cargo.toml
+++ b/pmemlog/Cargo.toml
@@ -13,3 +13,6 @@ crc64fast = "1.0.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ["cfg(verus_keep_ghost)"] }
+
+[package.metadata.verus]
+verify = true

--- a/pmemlog/README.md
+++ b/pmemlog/README.md
@@ -17,5 +17,5 @@ To verify the log, run the following.
 
 ```
 cd src
-verus lib.rs --crate-type=lib
+cargo verus verify
 ```

--- a/pmemlog/README.md
+++ b/pmemlog/README.md
@@ -13,8 +13,7 @@ Install Verus from `https://github.com/verus-lang/verus`.
 
 ### Verification
 
-To verify the log, run the following.
-
+To verify the log, `cd` to the `pmemlog/` directory and run the following.
 ```
 cd src
 cargo verus verify


### PR DESCRIPTION
This PR updates `capybaraKV`, `multilog`, and `pmemlog`'s documentation to use `cargo verus verify`, replacing the long command we had before to deal with external dependencies. The instructions also explain how to build/verify each crate on Linux/WSL with and without PM-related dependencies, MacOS, and Windows, and the PR includes some minor updates that should make those all work. 

I've only been able to test the new instructions on WSL (both with and without the PM dependencies); @jaylorch and @parno, would you be willing to test on Windows and Mac? You should be able to just run `cargo verus verify`/`cargo build` for all of the crates on those platforms. 