### PR TITLE
Support latest Verus, notably new Z3 version

### DIFF
--- a/capybaraKV/capybarakv/Cargo.toml
+++ b/capybaraKV/capybarakv/Cargo.toml
@@ -20,10 +20,7 @@ default = [ "pmem" ]
 crc64fast = "1.0.0"
 # Avoid default features since @lopopolo reports that rand is unsound with both the log and thread_rng features
 rand = { version = "0.10.1", default-features = false, features = [ "thread_rng" ] }
-vstd = { path = "../../../verus/source/vstd/" }
-verus_builtin = { path = "../../../verus/source/builtin/" }
-verus_builtin_macros = { path = "../../../verus/source/builtin_macros/" }
-#vstd = { version = "=0.0.0-2026-07-27-0206" }
+vstd = { version = "=0.0.0-2026-08-02-0125" }
 pmcopy = { path = "../pmcopy" }
 
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/capybaraKV/capybarakv/Cargo.toml
+++ b/capybaraKV/capybarakv/Cargo.toml
@@ -20,7 +20,10 @@ default = [ "pmem" ]
 crc64fast = "1.0.0"
 # Avoid default features since @lopopolo reports that rand is unsound with both the log and thread_rng features
 rand = { version = "0.10.1", default-features = false, features = [ "thread_rng" ] }
-vstd = { git = "https://github.com/verus-lang/verus.git" }
+vstd = { path = "../../../verus/source/vstd/" }
+verus_builtin = { path = "../../../verus/source/builtin/" }
+verus_builtin_macros = { path = "../../../verus/source/builtin_macros/" }
+#vstd = { version = "=0.0.0-2026-07-27-0206" }
 pmcopy = { path = "../pmcopy" }
 
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/capybaraKV/capybarakv/rust-toolchain.toml
+++ b/capybaraKV/capybarakv/rust-toolchain.toml
@@ -5,5 +5,5 @@
 # be used with a nightly toolchain.
 
 [toolchain]
-channel = "nightly-2026-04-19"
+channel = "nightly-2026-07-12"
 

--- a/capybaraKV/capybarakv/src/common/saturate_v.rs
+++ b/capybaraKV/capybarakv/src/common/saturate_v.rs
@@ -195,6 +195,16 @@ impl SaturatingU64 {
         }
         let i: Ghost<int> = Ghost(self@ * v2);
         if v2 == 0 || self.v == 0 {
+            proof {
+                // self@ == self.i and (in the non-saturated case) self.i == self.v, so when either
+                // v2 or self.v is 0 the product self@ * v2 is 0 and the type invariant (v == i) holds.
+                if v2 == 0 {
+                    vstd::arithmetic::mul::lemma_mul_by_zero_is_zero(self@);
+                } else {
+                    assert(self@ == 0);
+                    vstd::arithmetic::mul::lemma_mul_by_zero_is_zero(v2 as int);
+                }
+            }
             Self{ i, v: 0 }
         }
         else if self.v > u64::MAX / v2 {

--- a/capybaraKV/capybarakv/src/kv2/keys/crud_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/keys/crud_v.rs
@@ -711,8 +711,8 @@ where
         broadcast use vstd::std_specs::hash::group_hash_axioms;
 
         let mut result = Vec::<K>::new();
-        let ghost keys = self.m.keys();
-        for k in iter: self.m.keys()
+        let keys = self.m.keys();
+        for k in iter: keys
             invariant
                 result@ == iter.seq().take(iter.index@).unref(),
         {
@@ -720,7 +720,7 @@ where
         }
 
         assert(result@.to_set() =~= self@.tentative.unwrap().key_info.dom()) by {
-             assert(keys.remaining().take(keys.remaining().len() as int) == keys.remaining());
+            assert(keys.remaining().take(keys.remaining().len() as int) == keys.remaining());
 //            assert(keys.remaining().to_set() == self.m@.dom());
 //            assert(keys@.1.take(keys@.1.len() as int) =~= keys@.1);
             assert(self.m@.dom() =~= self@.tentative.unwrap().key_info.dom());

--- a/capybaraKV/capybarakv/src/kv2/lists/trim_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/lists/trim_v.rs
@@ -50,6 +50,16 @@ impl<L> ListRecoveryMapping<L>
             list_elements: self.list_elements.remove(list_addr).insert(new_head, new_elements),
         }
     }
+
+    proof fn lemma_list_info_has_elements(self, head: u64, sm: ListTableStaticMetadata)
+        requires
+            self.internally_consistent(sm),
+            self.list_info.contains_key(head),
+        ensures
+            self.list_elements.contains_key(head),
+    {
+    }
+
 }
 
 impl<L> ListTableEntryView<L>
@@ -281,6 +291,37 @@ impl<L> ListTableInternalView<L>
         self.lemma_trim_preserves_valid(list_addr, trim_length, sm);
     }
 
+    proof fn lemma_trim_preserves_internal_consistency(
+        self,
+        list_addr: u64,
+        trim_length: int,
+        sm: ListTableStaticMetadata,
+    )
+        requires
+            sm.valid::<L>(),
+            self.valid(sm),
+            0 < sm.start(),
+            self.m.contains_key(list_addr),
+            0 < trim_length < self.m[list_addr].length(),
+        ensures
+            self.trim(list_addr, trim_length).tentative_mapping.internally_consistent(sm),
+            self.trim(list_addr, trim_length).row_info_consistent(sm),
+            self.trim(list_addr, trim_length).pending_deallocations_consistent(sm),
+            self.tentative_mapping.list_info[list_addr][trim_length] != list_addr,
+            !self.tentative_mapping.list_info.contains_key(
+                self.tentative_mapping.list_info[list_addr][trim_length]
+            ),
+            !self.m.contains_key(self.tentative_mapping.list_info[list_addr][trim_length]),
+    {
+        let new_head = self.tentative_mapping.list_info[list_addr][trim_length];
+        assert(new_head > 0) by {
+            broadcast use group_validate_row_addr;
+        }
+        assert(new_head != list_addr);
+        assert(!self.tentative_mapping.list_info.contains_key(new_head));
+        assert(!self.m.contains_key(new_head));
+    }
+
     #[verifier::spinoff_prover]
     #[verifier::rlimit(100)]
     pub(super) proof fn lemma_trim_preserves_valid(
@@ -300,11 +341,13 @@ impl<L> ListTableInternalView<L>
         ensures
             self.trim(list_addr, trim_length).valid(sm),
     {
+        hide(ListRecoveryMapping::internally_consistent);
         let new_head = self.tentative_mapping.list_info[list_addr][trim_length];
         let new_self = self.trim(list_addr, trim_length);
-        assert(new_head > 0) by {
-            broadcast use group_validate_row_addr;
-        }
+        self.lemma_trim_preserves_internal_consistency(list_addr, trim_length, sm);
+        assert(new_self.m.contains_key(new_head));
+        assert(new_self.tentative_mapping.list_info.contains_key(new_head));
+        assert(new_self.tentative_mapping.list_elements.contains_key(new_head));
         if let ListTableEntryView::Modified{ durable_head, summary, addrs, elements, .. } = new_self.m[new_head] {
             let tentative_addrs = new_self.tentative_mapping.list_info[new_head];
             let tentative_elements = new_self.tentative_mapping.list_elements[new_head];
@@ -313,9 +356,10 @@ impl<L> ListTableInternalView<L>
                 assert(tentative_elements =~= elements);
             }
             else {
+                assert(new_self.durable_mapping.list_info.contains_key(durable_head));
+                new_self.durable_mapping.lemma_list_info_has_elements(durable_head, sm);
                 let durable_addrs = new_self.durable_mapping.list_info[durable_head];
                 let durable_elements = new_self.durable_mapping.list_elements[durable_head];
-                assert(new_self.durable_mapping.list_info.contains_key(durable_head));
                 assert(tentative_addrs =~=
                        durable_addrs.skip(durable_addrs.len() - (summary.length - addrs.len())) + addrs);
                 assert(tentative_elements =~=
@@ -323,6 +367,9 @@ impl<L> ListTableInternalView<L>
                        elements);
             }
         }
+
+        assert(new_self.m_consistent_with_recovery_mappings());
+        assert(new_self.per_row_info_consistent(sm));
     }
 }
 

--- a/capybaraKV/capybarakv/src/kv2/lists/trim_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/lists/trim_v.rs
@@ -277,6 +277,34 @@ impl<L> ListTableInternalView<L>
         assert(self.trim(list_addr, trim_length).tentative_mapping.as_snapshot() =~=
                self.tentative_mapping.as_snapshot().trim(list_addr, new_head, trim_length));
 
+        // Discharge valid() in a separate lemma to keep proof times manageable
+        self.lemma_trim_preserves_valid(list_addr, trim_length, sm);
+    }
+
+    #[verifier::spinoff_prover]
+    #[verifier::rlimit(100)]
+    pub(super) proof fn lemma_trim_preserves_valid(
+        self,
+        list_addr: u64,
+        trim_length: int,
+        sm: ListTableStaticMetadata
+    )
+        requires
+            sm.valid::<L>(),
+            self.valid(sm),
+            0 < sm.start(),
+            self.durable_mapping.internally_consistent(sm),
+            self.tentative_mapping.internally_consistent(sm),
+            self.m.contains_key(list_addr),
+            0 < trim_length < self.m[list_addr].length(),
+        ensures
+            self.trim(list_addr, trim_length).valid(sm),
+    {
+        let new_head = self.tentative_mapping.list_info[list_addr][trim_length];
+        let new_self = self.trim(list_addr, trim_length);
+        assert(new_head > 0) by {
+            broadcast use group_validate_row_addr;
+        }
         if let ListTableEntryView::Modified{ durable_head, summary, addrs, elements, .. } = new_self.m[new_head] {
             let tentative_addrs = new_self.tentative_mapping.list_info[new_head];
             let tentative_elements = new_self.tentative_mapping.list_elements[new_head];

--- a/capybaraKV/capybarakv/src/kv2/lists/update_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/lists/update_v.rs
@@ -838,6 +838,7 @@ where
         }
     }
 
+    #[verifier::rlimit(50)]
     proof fn lemma_update_normal_case(
         old_iv: ListTableInternalView<L>,
         new_iv: ListTableInternalView<L>,

--- a/capybaraKV/capybarakv/src/kv2/lists/update_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/lists/update_v.rs
@@ -265,6 +265,269 @@ impl<L> ListTableInternalView<L>
             _ => { assert(false); },
         }
     }
+
+    proof fn lemma_update_mapping_internally_consistent(
+        self,
+        list_addr: u64,
+        idx: usize,
+        new_element: L,
+        sm: ListTableStaticMetadata,
+    )
+        requires
+            sm.valid::<L>(),
+            self.valid(sm),
+            0 < sm.start(),
+            0 < self.free_list.len(),
+            self.m.contains_key(list_addr),
+            match self.m[list_addr] {
+                ListTableEntryView::Modified{ summary, addrs, elements, .. } => {
+                    &&& summary.length == addrs.len()
+                    &&& addrs.len() == elements.len()
+                    &&& idx < addrs.len()
+                    &&& elements[idx as int].start() == new_element.start()
+                    &&& elements[idx as int].end() == new_element.end()
+                },
+                _ => false,
+            },
+        ensures
+            self.update(list_addr, idx, new_element).tentative_mapping.internally_consistent(sm),
+    {
+        self.lemma_update_works(list_addr, idx, new_element, sm);
+    }
+
+    proof fn lemma_tentative_rows_are_valid(self, sm: ListTableStaticMetadata)
+        requires
+            self.tentative_mapping.internally_consistent(sm),
+        ensures
+            forall|row_addr: u64| #[trigger] self.tentative_mapping.row_info.contains_key(row_addr) ==>
+                sm.table.validate_row_addr(row_addr),
+    {
+    }
+
+    proof fn lemma_update_preserves_tentative_state(
+        self,
+        new_self: Self,
+        list_addr: u64,
+        idx: usize,
+        new_element: L,
+        old_state: Seq<u8>,
+        new_state: Seq<u8>,
+        sm: ListTableStaticMetadata,
+        new_row_addr: u64,
+    )
+        requires
+            sm.valid::<L>(),
+            self.tentative_mapping.row_info_corresponds(old_state, sm),
+            new_self.tentative_mapping.internally_consistent(sm),
+            self.tentative_mapping.list_info.contains_key(list_addr),
+            idx < self.tentative_mapping.list_info[list_addr].len(),
+            new_self == self.update(list_addr, idx, new_element),
+            0 < self.free_list.len(),
+            new_row_addr == self.free_list.last(),
+            ({
+                let addrs = self.tentative_mapping.list_info[list_addr];
+                let next: u64 = if idx == addrs.len() - 1 { 0 } else { addrs[idx + 1] };
+                &&& recover_object::<L>(new_state, new_row_addr + sm.row_element_start,
+                                        new_row_addr + sm.row_element_crc_start) == Some(new_element)
+                &&& recover_object::<u64>(new_state, new_row_addr + sm.row_next_start,
+                                          new_row_addr + sm.row_next_start + u64::spec_size_of()) == Some(next)
+                &&& forall|other_row_addr: u64| {
+                    &&& sm.table.validate_row_addr(other_row_addr)
+                    &&& other_row_addr != new_row_addr
+                } ==> {
+                    recover_object::<L>(new_state, other_row_addr + sm.row_element_start,
+                                        other_row_addr + sm.row_element_crc_start) ==
+                    recover_object::<L>(old_state, other_row_addr + sm.row_element_start,
+                                        other_row_addr + sm.row_element_crc_start)
+                }
+            }),
+            if idx > 0 {
+                let addrs = self.tentative_mapping.list_info[list_addr];
+                let prev_row_addr: u64 = addrs[idx - 1];
+                &&& recover_object::<u64>(new_state, prev_row_addr + sm.row_next_start,
+                                          prev_row_addr + sm.row_next_start + u64::spec_size_of()) ==
+                        Some(new_row_addr)
+                &&& forall|other_row_addr: u64| {
+                    &&& sm.table.validate_row_addr(other_row_addr)
+                    &&& other_row_addr != new_row_addr
+                    &&& other_row_addr != prev_row_addr
+                } ==> {
+                    recover_object::<u64>(new_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of()) ==
+                    recover_object::<u64>(old_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of())
+                }
+            } else {
+                forall|other_row_addr: u64| {
+                    &&& sm.table.validate_row_addr(other_row_addr)
+                    &&& other_row_addr != new_row_addr
+                } ==> {
+                    recover_object::<u64>(new_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of()) ==
+                    recover_object::<u64>(old_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of())
+                }
+            },
+        ensures
+            new_self.corresponds_to_tentative_state(new_state, sm),
+    {
+        hide(ListRecoveryMapping::internally_consistent);
+        hide(ListRecoveryMapping::row_info_corresponds);
+        new_self.lemma_tentative_rows_are_valid(sm);
+        self.lemma_update_preserves_row_info_correspondence(
+            new_self, list_addr, idx, new_element, old_state, new_state, sm, new_row_addr,
+        );
+        assert(new_self.corresponds_to_tentative_state(new_state, sm));
+    }
+
+    proof fn lemma_update_preserves_row_info_correspondence(
+        self,
+        new_self: Self,
+        list_addr: u64,
+        idx: usize,
+        new_element: L,
+        old_state: Seq<u8>,
+        new_state: Seq<u8>,
+        sm: ListTableStaticMetadata,
+        new_row_addr: u64,
+    )
+        requires
+            sm.valid::<L>(),
+            self.tentative_mapping.list_info.contains_key(list_addr),
+            idx < self.tentative_mapping.list_info[list_addr].len(),
+            new_self == self.update(list_addr, idx, new_element),
+            0 < self.free_list.len(),
+            new_row_addr == self.free_list.last(),
+            self.tentative_mapping.row_info_corresponds(old_state, sm),
+            forall|row_addr: u64| #[trigger] new_self.tentative_mapping.row_info.contains_key(row_addr) ==>
+                sm.table.validate_row_addr(row_addr),
+            ({
+                let addrs = self.tentative_mapping.list_info[list_addr];
+                let next: u64 = if idx == addrs.len() - 1 { 0 } else { addrs[idx + 1] };
+                &&& recover_object::<L>(new_state, new_row_addr + sm.row_element_start,
+                                        new_row_addr + sm.row_element_crc_start) == Some(new_element)
+                &&& recover_object::<u64>(new_state, new_row_addr + sm.row_next_start,
+                                          new_row_addr + sm.row_next_start + u64::spec_size_of()) == Some(next)
+                &&& forall|other_row_addr: u64| {
+                    &&& sm.table.validate_row_addr(other_row_addr)
+                    &&& other_row_addr != new_row_addr
+                } ==> {
+                    recover_object::<L>(new_state, other_row_addr + sm.row_element_start,
+                                        other_row_addr + sm.row_element_crc_start) ==
+                    recover_object::<L>(old_state, other_row_addr + sm.row_element_start,
+                                        other_row_addr + sm.row_element_crc_start)
+                }
+            }),
+            if idx > 0 {
+                let addrs = self.tentative_mapping.list_info[list_addr];
+                let prev_row_addr: u64 = addrs[idx - 1];
+                &&& recover_object::<u64>(new_state, prev_row_addr + sm.row_next_start,
+                                          prev_row_addr + sm.row_next_start + u64::spec_size_of()) ==
+                        Some(new_row_addr)
+                &&& forall|other_row_addr: u64| {
+                    &&& sm.table.validate_row_addr(other_row_addr)
+                    &&& other_row_addr != new_row_addr
+                    &&& other_row_addr != prev_row_addr
+                } ==> {
+                    recover_object::<u64>(new_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of()) ==
+                    recover_object::<u64>(old_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of())
+                }
+            } else {
+                forall|other_row_addr: u64| {
+                    &&& sm.table.validate_row_addr(other_row_addr)
+                    &&& other_row_addr != new_row_addr
+                } ==> {
+                    recover_object::<u64>(new_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of()) ==
+                    recover_object::<u64>(old_state, other_row_addr + sm.row_next_start,
+                                          other_row_addr + sm.row_next_start + u64::spec_size_of())
+                }
+            },
+        ensures
+            new_self.tentative_mapping.row_info_corresponds(new_state, sm),
+    {
+        broadcast use group_validate_row_addr;
+        broadcast use broadcast_update_bytes_effect;
+        broadcast use broadcast_seqs_match_in_range_can_narrow_range;
+        broadcast use pmcopy_axioms;
+    }
+
+    proof fn lemma_update_preserves_journaled_addrs(
+        self,
+        new_self: Self,
+        list_addr: u64,
+        idx: usize,
+        new_element: L,
+        old_journaled_addrs: Set<int>,
+        new_journaled_addrs: Set<int>,
+        sm: ListTableStaticMetadata,
+    )
+        requires
+            sm.valid::<L>(),
+            self.valid(sm),
+            self.consistent_with_journaled_addrs(old_journaled_addrs, sm),
+            self.tentative_mapping.list_info.contains_key(list_addr),
+            idx < self.tentative_mapping.list_info[list_addr].len(),
+            0 < self.free_list.len(),
+            new_self == self.update(list_addr, idx, new_element),
+            if idx > 0 {
+                let addrs = self.tentative_mapping.list_info[list_addr];
+                let prev_row_addr = addrs[idx - 1];
+                new_journaled_addrs ==
+                    old_journaled_addrs +
+                    Set::<int>::range(prev_row_addr + sm.row_next_start,
+                                      prev_row_addr + sm.row_next_start + u64::spec_size_of() + u64::spec_size_of())
+            } else {
+                new_journaled_addrs == old_journaled_addrs
+            },
+        ensures
+            new_self.consistent_with_journaled_addrs(new_journaled_addrs, sm),
+    {
+        broadcast use group_validate_row_addr;
+
+        assert(new_self.free_list == self.free_list.drop_last());
+        assert(self.tentative_mapping.internally_consistent(sm));
+        assert(self.free_list_consistent(sm));
+        assert(self.row_info_consistent(sm));
+
+        assert forall|i: int, addr: int| #![trigger new_self.free_list[i], new_journaled_addrs.contains(addr)] {
+            let row_addr = new_self.free_list[i];
+            &&& 0 <= i < new_self.free_list.len()
+            &&& row_addr <= addr < row_addr + sm.table.row_size
+        } implies !new_journaled_addrs.contains(addr) by {
+            let row_addr = new_self.free_list[i];
+            assert(0 <= i < new_self.free_list.len());
+            assert(new_self.free_list.len() == self.free_list.len() - 1);
+            assert(0 <= i < self.free_list.len());
+            assert(new_self.free_list[i] == self.free_list.drop_last()[i]);
+            assert(self.free_list.drop_last()[i] == self.free_list[i]);
+            assert(row_addr == self.free_list[i]);
+            assert(row_addr <= addr < row_addr + sm.table.row_size);
+            assert(!old_journaled_addrs.contains(addr));
+
+            if idx > 0 {
+                let addrs = self.tentative_mapping.list_info[list_addr];
+                let prev_row_addr = addrs[idx - 1];
+
+                assert(self.tentative_mapping.row_info.contains_key(prev_row_addr));
+                assert(self.row_info.contains_key(row_addr));
+                assert(self.row_info[row_addr] is InFreeList);
+                assert(!self.tentative_mapping.row_info.contains_key(row_addr));
+                assert(prev_row_addr != row_addr);
+                assert(sm.table.validate_row_addr(prev_row_addr));
+                assert(sm.table.validate_row_addr(row_addr));
+                assert(prev_row_addr + sm.row_next_start + u64::spec_size_of() + u64::spec_size_of()
+                       <= prev_row_addr + sm.table.row_size);
+                assert(!Set::<int>::range(
+                    prev_row_addr + sm.row_next_start,
+                    prev_row_addr + sm.row_next_start + u64::spec_size_of() + u64::spec_size_of(),
+                ).contains(addr));
+            }
+        }
+    }
+
 }
 
 impl<PM, L> ListTable<PM, L>
@@ -838,7 +1101,6 @@ where
         }
     }
 
-    #[verifier::rlimit(50)]
     proof fn lemma_update_normal_case(
         old_iv: ListTableInternalView<L>,
         new_iv: ListTableInternalView<L>,
@@ -945,11 +1207,27 @@ where
                 &&& old_list[idx as int].end() == new_element.end()
             }),
     {
-        broadcast use group_validate_row_addr;
-        broadcast use broadcast_update_bytes_effect;
-        broadcast use broadcast_seqs_match_in_range_can_narrow_range;
-        broadcast use pmcopy_axioms;
-        
+        old_iv.lemma_update_mapping_internally_consistent(list_addr, idx, new_element, sm);
+        old_iv.lemma_update_preserves_tentative_state(
+            new_iv,
+            list_addr,
+            idx,
+            new_element,
+            old_jv.commit_state,
+            new_jv.commit_state,
+            sm,
+            new_row_addr,
+        );
+        old_iv.lemma_update_preserves_journaled_addrs(
+            new_iv,
+            list_addr,
+            idx,
+            new_element,
+            old_jv.journaled_addrs,
+            new_jv.journaled_addrs,
+            sm,
+        );
+
         old_iv.lemma_update_works(list_addr, idx, new_element, sm);
     }
 

--- a/capybaraKV/capybarakv/src/kv2/setup_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/setup_v.rs
@@ -38,7 +38,7 @@ where
     I: PmCopy + std::fmt::Debug,
     L: PmCopy + LogicalRange + std::fmt::Debug + Copy,
 {
-    pub exec fn space_needed_for_journal_capacity(ps: &SetupParameters) -> (result: CheckedU64)
+    exec fn space_needed_for_journal_capacity(ps: &SetupParameters) -> (result: CheckedU64)
         ensures
             result@ == ps.max_operations_per_transaction * spec_space_needed_for_transaction_operation(),
     {

--- a/capybaraKV/capybarakv/src/kv2/shardkv_v.rs
+++ b/capybaraKV/capybarakv/src/kv2/shardkv_v.rs
@@ -223,6 +223,140 @@ where
     }
 }
 
+spec fn setup_loop_invariant<K, I, L>(
+    idx: usize,
+    nshards: usize,
+    ps: SetupParameters,
+    pm_constants: PersistentMemoryConstants,
+    shard_res_old: Map<int, GhostVar<ConcurrentKvStoreView::<K, I, L>>>,
+    shard_res: Map<int, GhostVar<ConcurrentKvStoreView::<K, I, L>>>,
+    pred: ShardingPredicate,
+    shardstates: ShardStates::<K, I, L>,
+    combined_res: GhostVar<ConcurrentKvStoreView<K, I, L>>,
+) -> bool
+where
+    K: Hash + PmCopy + Sized + std::fmt::Debug,
+    I: PmCopy + Sized + std::fmt::Debug,
+    L: PmCopy + LogicalRange + std::fmt::Debug + Copy,
+{
+    &&& nshards >= 1
+    &&& forall |shard| 0 <= shard < nshards ==> #[trigger] shard_res_old.contains_key(shard)
+    &&& forall |shard| #[trigger] shard_res_old.contains_key(shard) ==> {
+        &&& shard_res_old[shard]@.ps == ps
+        &&& shard_res_old[shard]@.pm_constants == pm_constants
+        &&& shard_res_old[shard]@.kv == RecoveredKvStore::<K, I, L>::init(ps).kv
+    }
+    &&& pred.shard_ids.len() == idx
+    &&& pred.combined_id == shardstates.combined.id()
+    &&& pred.combined_id == combined_res.id()
+    &&& pred.pm_constants == shardstates.combined@.pm_constants
+    &&& forall |shard| 0 <= shard < idx ==>
+        #[trigger] pred.shard_ids[shard] == shard_res_old[shard].id()
+    &&& shardstates.combined@ == (ConcurrentKvStoreView::<K, I, L>{
+        ps: ps,
+        pm_constants: pm_constants,
+        kv: RecoveredKvStore::<K, I, L>::init(ps).kv,
+    })
+    &&& forall |shard| idx <= shard < nshards ==> #[trigger] shard_res.contains_key(shard)
+    &&& forall |shard| #[trigger] shard_res.contains_key(shard) ==> {
+        &&& shard_res_old.contains_key(shard)
+        &&& shard_res[shard] == shard_res_old[shard]
+        &&& shard_res[shard]@.ps == ps
+        &&& shard_res[shard]@.pm_constants == pm_constants
+        &&& shard_res[shard]@.kv == RecoveredKvStore::<K, I, L>::init(ps).kv
+    }
+    &&& forall |shard| 0 <= shard < idx ==> #[trigger] shardstates.shards.contains_key(shard)
+    &&& forall |shard| #[trigger] shardstates.shards.contains_key(shard) ==> {
+        &&& 0 <= shard < idx
+        &&& shardstates.shards[shard].kv_state.id() == pred.shard_ids[shard]
+        &&& shardstates.shards[shard].kv_state@ == ConcurrentKvStoreView::<K, I, L>{
+            ps: ps,
+            pm_constants: pm_constants,
+            kv: RecoveredKvStore::<K, I, L>::init(ps).kv,
+        }
+    }
+}
+
+proof fn lemma_setup_loop_preserves_invariant<K, I, L>(
+    prev_idx: usize,
+    idx: usize,
+    nshards: usize,
+    ps: SetupParameters,
+    pm_constants: PersistentMemoryConstants,
+    shard_res_old: Map<int, GhostVar<ConcurrentKvStoreView::<K, I, L>>>,
+    combined_res: GhostVar<ConcurrentKvStoreView<K, I, L>>,
+    prev_shard_res: Map<int, GhostVar<ConcurrentKvStoreView::<K, I, L>>>,
+    prev_pred: ShardingPredicate,
+    prev_shardstates: ShardStates<K, I, L>,
+    shardstate: ShardState<K, I, L>,
+    shard_res: Map<int, GhostVar<ConcurrentKvStoreView::<K, I, L>>>,
+    pred: ShardingPredicate,
+    shardstates: ShardStates<K, I, L>,
+)
+where
+    K: Hash + PmCopy + Sized + std::fmt::Debug,
+    I: PmCopy + Sized + std::fmt::Debug,
+    L: PmCopy + LogicalRange + std::fmt::Debug + Copy,
+    requires
+        prev_idx < nshards,
+        idx == prev_idx + 1,
+        setup_loop_invariant(prev_idx, nshards, ps, pm_constants, shard_res_old,
+                             prev_shard_res, prev_pred, prev_shardstates, combined_res),
+        prev_shard_res.contains_key(prev_idx as int),
+        shardstate == (ShardState::<K, I, L>{ kv_state: prev_shard_res[prev_idx as int] }),
+        shard_res == prev_shard_res.remove(prev_idx as int),
+        pred == (ShardingPredicate{
+            shard_ids: prev_pred.shard_ids.push(shardstate.kv_state.id()),
+            ..prev_pred
+        }),
+        shardstates == (ShardStates::<K, I, L>{
+            shards: prev_shardstates.shards.insert(prev_idx as int, shardstate),
+            ..prev_shardstates
+        }),
+    ensures
+        setup_loop_invariant(idx, nshards, ps, pm_constants, shard_res_old,
+                             shard_res, pred, shardstates, combined_res),
+{
+    assert(pred.shard_ids.len() == idx);
+    assert(pred.combined_id == shardstates.combined.id());
+    assert(pred.combined_id == combined_res.id());
+    assert(pred.pm_constants == shardstates.combined@.pm_constants);
+
+    assert forall |shard| 0 <= shard < idx implies
+        #[trigger] pred.shard_ids[shard] == shard_res_old[shard].id() by {
+        if shard < prev_pred.shard_ids.len() {
+            assert(pred.shard_ids[shard] == prev_pred.shard_ids[shard]);
+        } else {
+            assert(shard == prev_idx);
+            assert(pred.shard_ids[shard] == shardstate.kv_state.id());
+        }
+    }
+
+    assert(shardstates.combined@ == (ConcurrentKvStoreView::<K, I, L>{
+        ps: ps,
+        pm_constants: pm_constants,
+        kv: RecoveredKvStore::<K, I, L>::init(ps).kv,
+    }));
+    assert(forall |shard| idx <= shard < nshards ==> #[trigger] shard_res.contains_key(shard));
+    assert(forall |shard| #[trigger] shard_res.contains_key(shard) ==> {
+        &&& shard_res_old.contains_key(shard)
+        &&& shard_res[shard] == shard_res_old[shard]
+        &&& shard_res[shard]@.ps == ps
+        &&& shard_res[shard]@.pm_constants == pm_constants
+        &&& shard_res[shard]@.kv == RecoveredKvStore::<K, I, L>::init(ps).kv
+    });
+    assert(forall |shard| 0 <= shard < idx ==> #[trigger] shardstates.shards.contains_key(shard));
+    assert(forall |shard| #[trigger] shardstates.shards.contains_key(shard) ==> {
+        &&& 0 <= shard < idx
+        &&& shardstates.shards[shard].kv_state.id() == pred.shard_ids[shard]
+        &&& shardstates.shards[shard].kv_state@ == ConcurrentKvStoreView::<K, I, L>{
+            ps: ps,
+            pm_constants: pm_constants,
+            kv: RecoveredKvStore::<K, I, L>::init(ps).kv,
+        }
+    });
+}
+
 impl<PM, K, I, L> ShardedKvStoreTrait<PM, K, I, L> for ShardedKvStore<PM, K, I, L>
 where
     PM: PersistentMemoryRegion,
@@ -270,48 +404,22 @@ where
 
         for idx in 0..nshards
             invariant
-                nshards >= 1,
-                forall |shard| 0 <= shard < nshards ==> #[trigger] shard_res_old.contains_key(shard),
-                forall |shard| #[trigger] shard_res_old.contains_key(shard) ==> {
-                    &&& shard_res_old[shard]@.ps == ps
-                    &&& shard_res_old[shard]@.pm_constants == pm_constants
-                    &&& shard_res_old[shard]@.kv == RecoveredKvStore::<K, I, L>::init(ps).kv
-                },
-                pred.shard_ids.len() == idx,
-                pred.combined_id == shardstates.combined.id(),
-                pred.combined_id == combined_res.id(),
-                pred.pm_constants == shardstates.combined@.pm_constants,
-                forall |shard| 0 <= shard < idx ==>
-                    #[trigger] pred.shard_ids[shard] == shard_res_old[shard].id(),
-                shardstates.combined@ == (ConcurrentKvStoreView::<K, I, L>{
-                    ps: ps,
-                    pm_constants: pm_constants,
-                    kv: RecoveredKvStore::<K, I, L>::init(ps).kv,
-                }),
-                forall |shard| idx <= shard < nshards ==> #[trigger] shard_res.contains_key(shard),
-                forall |shard| #[trigger] shard_res.contains_key(shard) ==> {
-                    &&& shard_res[shard] == shard_res_old[shard]
-                    &&& shard_res[shard]@.ps == ps
-                    &&& shard_res[shard]@.pm_constants == pm_constants
-                    &&& shard_res[shard]@.kv == RecoveredKvStore::<K, I, L>::init(ps).kv
-                },
-                forall |shard| 0 <= shard < idx ==> #[trigger] shardstates.shards.contains_key(shard),
-                forall |shard| #[trigger] shardstates.shards.contains_key(shard) ==> {
-                    &&& 0 <= shard < idx
-                    &&& shardstates.shards[shard].kv_state.id() == pred.shard_ids[shard]
-                    &&& shardstates.shards[shard].kv_state@ == ConcurrentKvStoreView::<K, I, L>{
-                        ps: ps,
-                        pm_constants: pm_constants,
-                        kv: RecoveredKvStore::<K, I, L>::init(ps).kv,
-                    }
-                },
+                setup_loop_invariant::<K, I, L>(idx, nshards, ps, pm_constants, shard_res_old,
+                                                shard_res, pred, shardstates, combined_res),
         {
             proof {
+                let ghost prev_shard_res = shard_res;
+                let ghost prev_pred = pred;
+                let ghost prev_shardstates = shardstates;
                 let tracked shardstate = ShardState::<K, I, L>{
                     kv_state: shard_res.tracked_remove(idx as int),
                 };
                 pred.shard_ids = pred.shard_ids.push(shardstate.kv_state.id());
                 shardstates.shards.tracked_insert(idx as int, shardstate);
+                lemma_setup_loop_preserves_invariant(idx, (idx + 1) as usize, nshards,
+                                                     ps, pm_constants, shard_res_old, combined_res,
+                                                     prev_shard_res, prev_pred, prev_shardstates,
+                                                     shardstate, shard_res, pred, shardstates);
             }
         }
 

--- a/capybaraKV/pmcopy/rust-toolchain.toml
+++ b/capybaraKV/pmcopy/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"

--- a/multilog/multilog/Cargo.toml
+++ b/multilog/multilog/Cargo.toml
@@ -20,10 +20,7 @@ default = [ "pmem" ]
 crc64fast = "1.0.0"
 # Avoid default features since @lopopolo reports that rand is unsound with both the log and thread_rng features
 rand = { version = "0.10.1", default-features = false, features = [ "thread_rng" ] }
-vstd = { path = "../../../verus/source/vstd/" }
-verus_builtin = { path = "../../../verus/source/builtin/" }
-verus_builtin_macros = { path = "../../../verus/source/builtin_macros/" }
-#vstd = { version = "=0.0.0-2026-07-27-0206" }
+vstd = { version = "=0.0.0-2026-08-02-0125" }
 pmsafe = { path = "../pmsafe" }
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["errhandlingapi", "fileapi", "handleapi", "memoryapi", "winbase", "winerror", "winnt"] }

--- a/multilog/multilog/Cargo.toml
+++ b/multilog/multilog/Cargo.toml
@@ -20,7 +20,10 @@ default = [ "pmem" ]
 crc64fast = "1.0.0"
 # Avoid default features since @lopopolo reports that rand is unsound with both the log and thread_rng features
 rand = { version = "0.10.1", default-features = false, features = [ "thread_rng" ] }
-vstd = { git = "https://github.com/verus-lang/verus.git" }
+vstd = { path = "../../../verus/source/vstd/" }
+verus_builtin = { path = "../../../verus/source/builtin/" }
+verus_builtin_macros = { path = "../../../verus/source/builtin_macros/" }
+#vstd = { version = "=0.0.0-2026-07-27-0206" }
 pmsafe = { path = "../pmsafe" }
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["errhandlingapi", "fileapi", "handleapi", "memoryapi", "winbase", "winerror", "winnt"] }

--- a/multilog/multilog/rust-toolchain.toml
+++ b/multilog/multilog/rust-toolchain.toml
@@ -5,4 +5,4 @@
 # be used with a nightly toolchain.
 
 [toolchain]
-channel = "nightly-2026-04-19"
+channel = "nightly-2026-07-12"

--- a/multilog/multilog/src/multilog/inv_v.rs
+++ b/multilog/multilog/src/multilog/inv_v.rs
@@ -436,7 +436,7 @@ verus! {
             } ==> metadata_types_set_in_region(pm_regions_view.flush().committed()[i], cdb)
     {} 
 
-    pub proof fn lemma_metadata_set_after_crash_in_region(
+    proof fn lemma_metadata_set_after_crash_in_region(
         pm_region_view: PersistentMemoryRegionView,
         cdb: bool 
     )
@@ -456,7 +456,7 @@ verus! {
         }
     }
 
-    pub proof fn lemma_metadata_set_after_crash_in_first_region(
+    proof fn lemma_metadata_set_after_crash_in_first_region(
         pm_regions_view: PersistentMemoryRegionsView,
         cdb: bool 
     )

--- a/multilog/pmsafe/rust-toolchain.toml
+++ b/multilog/pmsafe/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"

--- a/pmemlog/Cargo.toml
+++ b/pmemlog/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vstd = { path = "../../verus/source/vstd/" }
-verus_builtin = { path = "../../verus/source/builtin/" }
-verus_builtin_macros = { path = "../../verus/source/builtin_macros/" }
-#vstd = { version = "=0.0.0-2026-07-27-0206" }
+vstd = { version = "=0.0.0-2026-08-02-0125" }
 crc64fast = "1.0.0"
 
 [lints.rust]

--- a/pmemlog/Cargo.toml
+++ b/pmemlog/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vstd = { git = "https://github.com/verus-lang/verus.git" }
+vstd = { path = "../../verus/source/vstd/" }
+verus_builtin = { path = "../../verus/source/builtin/" }
+verus_builtin_macros = { path = "../../verus/source/builtin_macros/" }
+#vstd = { version = "=0.0.0-2026-07-27-0206" }
 crc64fast = "1.0.0"
 
 [lints.rust]

--- a/pmemlog/rust-toolchain.toml
+++ b/pmemlog/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"

--- a/pmemlog/src/logimpl_v.rs
+++ b/pmemlog/src/logimpl_v.rs
@@ -629,7 +629,6 @@ verus! {
         }
     }
 
-    #[verifier::rlimit(20)]
     pub proof fn lemma_append_ib_update_effect_on_committed<Perm: CheckPermission<Seq<u8>>>(
         pm: Seq<u8>,
         new_ib: u64,
@@ -749,30 +748,25 @@ verus! {
                 let old_physical_tail = spec_addr_logical_to_physical(old_header.metadata.tail as int, old_header.metadata.log_size as int);
                 assert(old_physical_tail == physical_tail);
 
-                let (_, _, old_data) = pm_to_views(pm);
-                let (_, _, new_data) = pm_to_views(pm);
+                let (_, _, data) = pm_to_views(pm);
 
                 if physical_head <= old_physical_tail {
                     if old_physical_tail + append_size >= contents_end {
-                        assert(new_log_state.log =~= new_data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) +
-                                                    new_data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
-                                                    new_data.subrange(0, new_physical_tail - contents_offset));
-                        assert(new_log_state.log =~= old_data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) +
-                                                    new_data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
-                                                    new_data.subrange(0, new_physical_tail - contents_offset));
+                        assert(new_log_state.log =~= data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) +
+                                                    data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
+                                                    data.subrange(0, new_physical_tail - contents_offset)) by {};
                         let len1 = (contents_end - old_physical_tail);
                         let len2 = bytes_to_append.len() - len1;
-                        assert(bytes_to_append =~= new_data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
-                                                    new_data.subrange(0, new_physical_tail - contents_offset));
-                        assert(new_log_state.log =~= old_data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) + bytes_to_append);
+                        assert(bytes_to_append =~= data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
+                                                    data.subrange(0, new_physical_tail - contents_offset)) by {};
+                        assert(new_log_state.log =~= data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) + bytes_to_append) by {};
                     } else {
-                        assert(old_data.subrange(0, old_physical_tail - contents_offset) =~= new_data.subrange(0, old_physical_tail - contents_offset));
-                        assert(new_data.subrange(old_physical_tail - contents_offset, old_physical_tail - contents_offset + append_size) =~= bytes_to_append);
+                        assert(data.subrange(old_physical_tail - contents_offset, old_physical_tail - contents_offset + append_size) =~= bytes_to_append) by {};
                     }
                 } else { // physical_tail < physical_head
                     assert(old_physical_tail + append_size < physical_head);
                 }
-                assert(new_log_state =~= old_log_state.append(bytes_to_append));
+                assert(new_log_state =~= old_log_state.append(bytes_to_append)) by {};
                 assert(perm.check_permission(new_pm));
             }
             _ => assert(false),
@@ -1120,7 +1114,7 @@ verus! {
                 match pm_state {
                     Some(pm_state) => {
                         &&& header.metadata.head == pm_state.head
-                        &&& pm_state.log.len() == header.metadata.tail - header.metadata.head
+                        &&& header.metadata.tail == pm_state.head + pm_state.log.len()
                     }
                     None => false
                 }
@@ -1147,6 +1141,7 @@ verus! {
                     // size is 0
                     lemma_mod_equal(head, tail, log_size);
                 }
+                assert(header.metadata.tail == pm_state.head + pm_state.log.len());
             }
             None => assert(false),
         }
@@ -1269,6 +1264,34 @@ verus! {
                    Some(inf_log) => tail == head + inf_log.log.len(),
                    None => false,
                }
+        }
+
+        pub proof fn lemma_complete_inv_pm_contents(&self, contents: Seq<u8>)
+            requires
+                Self::recover(contents) is Some,
+                ({
+                    let (ib, _, _) = pm_to_views(contents);
+                    let header_pos = if ib == cdb0_val { header1_pos } else { header2_pos };
+                    let header = spec_get_live_header(contents);
+                    let head = header.metadata.head;
+                    let tail = header.metadata.tail;
+                    let log_size = header.metadata.log_size;
+                    &&& ib == cdb0_val || ib == cdb1_val
+                    &&& spec_crc_bytes(contents.subrange(header_pos + header_head_offset, header_pos + header_size)) ==
+                          contents.subrange(header_pos + header_crc_offset, header_pos + header_crc_offset + 8)
+                    &&& log_size + contents_offset <= u64::MAX
+                    &&& tail - head < log_size
+                    &&& log_size + contents_offset == contents.len()
+                    &&& self.header_crc == header.crc
+                    &&& self.head == head
+                    &&& self.tail == tail
+                    &&& self.log_size == log_size
+                    &&& self.incorruptible_bool == ib
+                }),
+            ensures
+                self.inv_pm_contents(contents),
+        {
+            lemma_pm_state_header(contents);
         }
 
         // This is the invariant that the untrusted log implementation
@@ -1691,6 +1714,8 @@ verus! {
                 self.incorruptible_bool = new_ib;
                 self.tail = new_tail;
                 self.header_crc = new_crc_val;
+
+                proof { self.lemma_complete_inv_pm_contents(wrpm@); }
 
                 Ok(old_logical_tail)
             }

--- a/pmemlog/src/logimpl_v.rs
+++ b/pmemlog/src/logimpl_v.rs
@@ -629,7 +629,138 @@ verus! {
         }
     }
 
-    pub proof fn lemma_append_ib_update_effect_on_committed<Perm: CheckPermission<Seq<u8>>>(
+    proof fn lemma_append_ib_update_effect_on_recovery(
+        pm: Seq<u8>,
+        new_ib: u64,
+        bytes_to_append: Seq<u8>,
+        new_header_bytes: Seq<u8>,
+    )
+        requires
+            pm.len() > contents_offset,
+            UntrustedLogImpl::recover(pm) is Some,
+            new_ib == cdb0_val || new_ib == cdb1_val,
+            new_ib == cdb0_val ==>
+                pm.subrange(header1_pos as int, header1_pos + header_size) == new_header_bytes,
+            new_ib == cdb1_val ==>
+                pm.subrange(header2_pos as int, header2_pos + header_size) == new_header_bytes,
+            new_header_bytes.subrange(header_crc_offset as int, header_crc_offset + 8) ==
+                spec_crc_bytes(new_header_bytes.subrange(header_head_offset as int, header_size as int)),
+            ({
+                let new_header = spec_bytes_to_header(new_header_bytes);
+                let live_header = spec_get_live_header(pm);
+                &&& new_header.metadata.tail == live_header.metadata.tail + bytes_to_append.len()
+                &&& new_header.metadata.head == live_header.metadata.head
+                &&& new_header.metadata.log_size == live_header.metadata.log_size
+                &&& new_header.metadata.tail - new_header.metadata.head < new_header.metadata.log_size
+            }),
+            ({
+                let live_header = spec_get_live_header(pm);
+                let physical_head = spec_addr_logical_to_physical(live_header.metadata.head as int, live_header.metadata.log_size as int);
+                let physical_tail = spec_addr_logical_to_physical(live_header.metadata.tail as int, live_header.metadata.log_size as int);
+                let contents_end = (live_header.metadata.log_size + contents_offset) as int;
+                let append_size = bytes_to_append.len();
+                let len1 = (contents_end - physical_tail);
+                let len2 = bytes_to_append.len() - len1;
+
+                &&& physical_tail + append_size >= contents_end ==> {
+                    &&& pm.subrange(physical_tail, contents_end) =~= bytes_to_append.subrange(0, len1)
+                    &&& pm.subrange(contents_offset as int, contents_offset + len2) =~= bytes_to_append.subrange(len1 as int, append_size as int)
+                    &&& bytes_to_append =~= pm.subrange(physical_tail, contents_end) + pm.subrange(contents_offset as int, contents_offset + len2)
+                }
+                &&& physical_head <= physical_tail && physical_tail + append_size < contents_end ==> {
+                    pm.subrange(physical_tail, physical_tail + append_size) =~= bytes_to_append
+                }
+                &&& physical_tail < physical_head ==> {
+                    &&& physical_tail + append_size < physical_head
+                    &&& pm.subrange(physical_tail, physical_tail + append_size) =~= bytes_to_append
+                }
+            }),
+        ensures
+            ({
+                let ib_bytes = spec_u64_to_le_bytes(new_ib);
+                let new_pm = update_contents_to_reflect_write(pm, incorruptible_bool_pos as int, ib_bytes);
+                let old_log_state = UntrustedLogImpl::recover(pm);
+                let new_log_state = UntrustedLogImpl::recover(new_pm);
+                let new_live_header = spec_get_live_header(new_pm);
+                let (new_pm_ib, _, _) = pm_to_views(new_pm);
+                &&& match (old_log_state, new_log_state) {
+                        (Some(old_log_state), Some(new_log_state)) => {
+                            new_log_state =~= old_log_state.append(bytes_to_append)
+                        }
+                        _ => false,
+                    }
+                &&& new_live_header == spec_bytes_to_header(new_header_bytes)
+                &&& new_ib == new_pm_ib
+            }),
+    {
+        let ib_bytes = spec_u64_to_le_bytes(new_ib);
+        let live_header = spec_get_live_header(pm);
+        let append_size = bytes_to_append.len();
+        let contents_end = live_header.metadata.log_size + contents_offset;
+        let physical_tail = spec_addr_logical_to_physical(live_header.metadata.tail as int, live_header.metadata.log_size as int);
+
+        lemma_auto_spec_u64_to_from_le_bytes();
+
+        let new_pm = update_contents_to_reflect_write(pm, incorruptible_bool_pos as int, ib_bytes);
+        lemma_headers_unchanged(pm, new_pm);
+        assert(new_pm.subrange(incorruptible_bool_pos as int, incorruptible_bool_pos + 8) =~= ib_bytes);
+
+        let new_header = spec_bytes_to_header(new_header_bytes);
+        let (ib, headers, data) = pm_to_views(new_pm);
+        let header_pos = if new_ib == cdb0_val {
+            header1_pos
+        } else {
+            header2_pos
+        };
+        assert(new_pm.subrange(header_pos as int, header_pos + header_size) =~= new_header_bytes);
+        lemma_header_match(new_pm, header_pos as int, new_header);
+        lemma_header_correct(new_pm, new_header_bytes, header_pos as int);
+
+        let new_log_state = UntrustedLogImpl::recover(new_pm);
+        let old_log_state = UntrustedLogImpl::recover(pm);
+
+        match (new_log_state, old_log_state) {
+            (Some(new_log_state), Some(old_log_state)) => {
+                lemma_pm_state_header(new_pm);
+                lemma_pm_state_header(pm);
+
+                let old_header = spec_get_live_header(pm);
+                let live_header = spec_get_live_header(new_pm);
+                assert(live_header == new_header);
+
+                assert(live_header.metadata.head == old_header.metadata.head);
+                assert(live_header.metadata.tail == old_header.metadata.tail + bytes_to_append.len());
+
+                let physical_head = spec_addr_logical_to_physical(live_header.metadata.head as int, live_header.metadata.log_size as int);
+                let new_physical_tail = spec_addr_logical_to_physical(live_header.metadata.tail as int, live_header.metadata.log_size as int);
+                let old_physical_tail = spec_addr_logical_to_physical(old_header.metadata.tail as int, old_header.metadata.log_size as int);
+                assert(old_physical_tail == physical_tail);
+
+                let (_, _, data) = pm_to_views(pm);
+
+                if physical_head <= old_physical_tail {
+                    if old_physical_tail + append_size >= contents_end {
+                        assert(new_log_state.log =~= data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) +
+                                                    data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
+                                                    data.subrange(0, new_physical_tail - contents_offset));
+                        let len1 = (contents_end - old_physical_tail);
+                        let len2 = bytes_to_append.len() - len1;
+                        assert(bytes_to_append =~= data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
+                                                    data.subrange(0, new_physical_tail - contents_offset));
+                        assert(new_log_state.log =~= data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) + bytes_to_append);
+                    } else {
+                        assert(data.subrange(old_physical_tail - contents_offset, old_physical_tail - contents_offset + append_size) =~= bytes_to_append);
+                    }
+                } else {
+                    assert(old_physical_tail + append_size < physical_head);
+                }
+                assert(new_log_state =~= old_log_state.append(bytes_to_append));
+            }
+            _ => assert(false),
+        }
+    }
+
+    proof fn lemma_append_ib_update_effect_on_committed<Perm: CheckPermission<Seq<u8>>>(
         pm: Seq<u8>,
         new_ib: u64,
         bytes_to_append: Seq<u8>,
@@ -704,69 +835,15 @@ verus! {
                 &&& new_ib == new_pm_ib
             }),
     {
+        lemma_append_ib_update_effect_on_recovery(pm, new_ib, bytes_to_append, new_header_bytes);
+
         let ib_bytes = spec_u64_to_le_bytes(new_ib);
-        let live_header = spec_get_live_header(pm);
-        let append_size = bytes_to_append.len();
-        let contents_end = live_header.metadata.log_size + contents_offset;
-        let physical_tail = spec_addr_logical_to_physical(live_header.metadata.tail as int, live_header.metadata.log_size as int);
-
-        lemma_auto_spec_u64_to_from_le_bytes();
-
         let new_pm = update_contents_to_reflect_write(pm, incorruptible_bool_pos as int, ib_bytes);
-        lemma_headers_unchanged(pm, new_pm);
-        assert(new_pm.subrange(incorruptible_bool_pos as int, incorruptible_bool_pos + 8) =~= ib_bytes);
-
-        let new_header = spec_bytes_to_header(new_header_bytes);
-        let (ib, headers, data) = pm_to_views(new_pm);
-        let header_pos = if new_ib == cdb0_val {
-            header1_pos
-        } else {
-            header2_pos
-        };
-        assert(new_pm.subrange(header_pos as int, header_pos + header_size) =~= new_header_bytes);
-        lemma_header_match(new_pm, header_pos as int, new_header);
-        lemma_header_correct(new_pm, new_header_bytes, header_pos as int);
-
-        // prove that new pm has the append update
         let new_log_state = UntrustedLogImpl::recover(new_pm);
         let old_log_state = UntrustedLogImpl::recover(pm);
 
         match (new_log_state, old_log_state) {
             (Some(new_log_state), Some(old_log_state)) => {
-                lemma_pm_state_header(new_pm);
-                lemma_pm_state_header(pm);
-
-                let old_header = spec_get_live_header(pm);
-                let live_header = spec_get_live_header(new_pm);
-                assert(live_header == new_header);
-
-                assert(live_header.metadata.head == old_header.metadata.head);
-                assert(live_header.metadata.tail == old_header.metadata.tail + bytes_to_append.len());
-
-                let physical_head = spec_addr_logical_to_physical(live_header.metadata.head as int, live_header.metadata.log_size as int);
-                let new_physical_tail = spec_addr_logical_to_physical(live_header.metadata.tail as int, live_header.metadata.log_size as int);
-                let old_physical_tail = spec_addr_logical_to_physical(old_header.metadata.tail as int, old_header.metadata.log_size as int);
-                assert(old_physical_tail == physical_tail);
-
-                let (_, _, data) = pm_to_views(pm);
-
-                if physical_head <= old_physical_tail {
-                    if old_physical_tail + append_size >= contents_end {
-                        assert(new_log_state.log =~= data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) +
-                                                    data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
-                                                    data.subrange(0, new_physical_tail - contents_offset)) by {};
-                        let len1 = (contents_end - old_physical_tail);
-                        let len2 = bytes_to_append.len() - len1;
-                        assert(bytes_to_append =~= data.subrange(old_physical_tail - contents_offset, contents_end - contents_offset) +
-                                                    data.subrange(0, new_physical_tail - contents_offset)) by {};
-                        assert(new_log_state.log =~= data.subrange(physical_head - contents_offset, old_physical_tail - contents_offset) + bytes_to_append) by {};
-                    } else {
-                        assert(data.subrange(old_physical_tail - contents_offset, old_physical_tail - contents_offset + append_size) =~= bytes_to_append) by {};
-                    }
-                } else { // physical_tail < physical_head
-                    assert(old_physical_tail + append_size < physical_head);
-                }
-                assert(new_log_state =~= old_log_state.append(bytes_to_append)) by {};
                 assert(perm.check_permission(new_pm));
             }
             _ => assert(false),
@@ -1647,14 +1724,7 @@ verus! {
         {
             assert(permissions_depend_only_on_recovery_view(perm));
 
-            let pm = wrpm.get_pm_ref();
-            let ghost original_pm = wrpm@;
-
-            let physical_head = Self::addr_logical_to_physical(self.head, self.log_size);
-            let physical_tail = Self::addr_logical_to_physical(self.tail, self.log_size);
-            let contents_end = self.log_size + contents_offset;
             let append_size: u64 = bytes_to_append.len() as u64;
-            let old_logical_tail = self.tail;
 
             if self.tail > u64::MAX - append_size {
                 Err(InfiniteLogErr::InsufficientSpaceForAppend{ available_space: u64::MAX - self.tail })
@@ -1662,63 +1732,102 @@ verus! {
             else if append_size >= self.log_size - (self.tail - self.head) {
                 Err(InfiniteLogErr::InsufficientSpaceForAppend{ available_space: self.log_size - 1 - (self.tail - self.head) })
             } else {
-                let mut header_metadata =
-                    PersistentHeaderMetadata { head: self.head, tail: self.tail, log_size: self.log_size };
-                assert(header_metadata == spec_get_live_header(wrpm@).metadata);
+                let offset = self.untrusted_append_success(wrpm, bytes_to_append, append_size, Tracked(perm));
+                Ok(offset)
+            }
+        }
 
-                if physical_head <= physical_tail {
-                    if physical_tail >= contents_end - append_size {
-                        // wrap case
-                        self.append_wrap(wrpm, bytes_to_append, &header_metadata, Tracked(perm));
-                    } else {
-                        // no wrap
-                        self.append_no_wrap(wrpm, bytes_to_append, &header_metadata, Tracked(perm));
+        #[inline]
+        exec fn untrusted_append_success<Perm, PM>(
+            &mut self,
+            wrpm: &mut WriteRestrictedPersistentMemory<Perm, PM>,
+            bytes_to_append: &Vec<u8>,
+            append_size: u64,
+            Tracked(perm): Tracked<&Perm>
+        ) -> (offset: u64)
+            where
+                Perm: CheckPermission<Seq<u8>>,
+                PM: PersistentMemory
+            requires
+                old(self).inv(&*old(wrpm)),
+                Self::recover(old(wrpm)@) is Some,
+                permissions_depend_only_on_recovery_view(perm),
+                perm.check_permission(old(wrpm)@),
+                bytes_to_append@.len() as u64 <= u64::MAX - old(self).tail,
+                (bytes_to_append@.len() as u64) < old(self).log_size - (old(self).tail - old(self).head),
+                append_size == bytes_to_append.len(),
+                ({
+                    let old_log_state = Self::recover(old(wrpm)@);
+                    forall |pm_state| #[trigger] perm.check_permission(pm_state) <==> {
+                        let log_state = Self::recover(pm_state);
+                        log_state == old_log_state || log_state == Some(old_log_state.unwrap().append(bytes_to_append@))
                     }
-                } else { // physical_tail < physical_head
-                    if physical_tail + append_size >= physical_head {
-                        return Err(InfiniteLogErr::InsufficientSpaceForAppend { available_space: physical_head - physical_tail });
-                    }
-                    // no wrap
+                }),
+            ensures
+                final(self).inv(final(wrpm)),
+                final(wrpm).constants() == old(wrpm).constants(),
+                ({
+                    let old_log_state = Self::recover(old(wrpm)@);
+                    let new_log_state = Self::recover(final(wrpm)@);
+                    &&& offset as nat == old_log_state.unwrap().log.len() + old_log_state.unwrap().head
+                    &&& new_log_state == Some(old_log_state.unwrap().append(bytes_to_append@))
+                }),
+        {
+            let physical_head = Self::addr_logical_to_physical(self.head, self.log_size);
+            let physical_tail = Self::addr_logical_to_physical(self.tail, self.log_size);
+            let contents_end = self.log_size + contents_offset;
+            let old_logical_tail = self.tail;
+
+            let mut header_metadata =
+                PersistentHeaderMetadata { head: self.head, tail: self.tail, log_size: self.log_size };
+            assert(header_metadata == spec_get_live_header(wrpm@).metadata);
+
+            if physical_head <= physical_tail {
+                if physical_tail >= contents_end - append_size {
+                    self.append_wrap(wrpm, bytes_to_append, &header_metadata, Tracked(perm));
+                } else {
                     self.append_no_wrap(wrpm, bytes_to_append, &header_metadata, Tracked(perm));
                 }
-
-                let new_tail = self.tail + append_size;
-                header_metadata.tail = new_tail;
-
-                let mut metadata_bytes = metadata_to_bytes(&header_metadata);
-                let new_crc_bytes = bytes_crc(&metadata_bytes);
-                let new_crc_val = u64_from_le_bytes(new_crc_bytes.as_slice());
-                let ghost old_metadata_bytes = metadata_bytes@;
-                let mut new_header_bytes = new_crc_bytes;
-                new_header_bytes.append(&mut metadata_bytes);
-
-                proof { lemma_header_crc_correct(new_header_bytes@, new_crc_bytes@, old_metadata_bytes); }
-
-                self.update_header(wrpm, Tracked(perm), &new_header_bytes);
-
-                // update incorruptible boolean
-                let old_ib = self.incorruptible_bool;
-                let new_ib = if old_ib == cdb0_val {
-                    cdb1_val
-                } else {
-                    assert(old_ib == cdb1_val);
-                    cdb0_val
-                };
-                let new_ib_bytes = u64_to_le_bytes(new_ib);
-
-                proof {
-                    lemma_append_ib_update(wrpm@, new_ib, bytes_to_append@, new_header_bytes@, perm);
-                }
-
-                wrpm.write(incorruptible_bool_pos, new_ib_bytes.as_slice(), Tracked(perm));
-                self.incorruptible_bool = new_ib;
-                self.tail = new_tail;
-                self.header_crc = new_crc_val;
-
-                proof { self.lemma_complete_inv_pm_contents(wrpm@); }
-
-                Ok(old_logical_tail)
+            } else {
+                assert(physical_tail + append_size < physical_head);
+                self.append_no_wrap(wrpm, bytes_to_append, &header_metadata, Tracked(perm));
             }
+
+            let new_tail = self.tail + append_size;
+            header_metadata.tail = new_tail;
+
+            let mut metadata_bytes = metadata_to_bytes(&header_metadata);
+            let new_crc_bytes = bytes_crc(&metadata_bytes);
+            let new_crc_val = u64_from_le_bytes(new_crc_bytes.as_slice());
+            let ghost old_metadata_bytes = metadata_bytes@;
+            let mut new_header_bytes = new_crc_bytes;
+            new_header_bytes.append(&mut metadata_bytes);
+
+            proof { lemma_header_crc_correct(new_header_bytes@, new_crc_bytes@, old_metadata_bytes); }
+
+            self.update_header(wrpm, Tracked(perm), &new_header_bytes);
+
+            let old_ib = self.incorruptible_bool;
+            let new_ib = if old_ib == cdb0_val {
+                cdb1_val
+            } else {
+                assert(old_ib == cdb1_val);
+                cdb0_val
+            };
+            let new_ib_bytes = u64_to_le_bytes(new_ib);
+
+            proof {
+                lemma_append_ib_update(wrpm@, new_ib, bytes_to_append@, new_header_bytes@, perm);
+            }
+
+            wrpm.write(incorruptible_bool_pos, new_ib_bytes.as_slice(), Tracked(perm));
+            self.incorruptible_bool = new_ib;
+            self.tail = new_tail;
+            self.header_crc = new_crc_val;
+
+            proof { self.lemma_complete_inv_pm_contents(wrpm@); }
+
+            old_logical_tail
         }
 
         exec fn append_no_wrap<Perm, PM>(

--- a/pmemlog/src/logimpl_v.rs
+++ b/pmemlog/src/logimpl_v.rs
@@ -81,12 +81,12 @@ verus! {
         }
     }
 
-    pub open spec fn permissions_depend_only_on_recovery_view<Perm: CheckPermission<Seq<u8>>>(perm: &Perm) -> bool
+    spec fn permissions_depend_only_on_recovery_view<Perm: CheckPermission<Seq<u8>>>(perm: &Perm) -> bool
     {
         forall |s1, s2| recovery_view()(s1) == recovery_view()(s2) ==> perm.check_permission(s1) == perm.check_permission(s2)
     }
 
-    pub proof fn lemma_same_permissions<Perm: CheckPermission<Seq<u8>>>(pm1: Seq<u8>, pm2: Seq<u8>, perm: &Perm)
+    proof fn lemma_same_permissions<Perm: CheckPermission<Seq<u8>>>(pm1: Seq<u8>, pm2: Seq<u8>, perm: &Perm)
         requires
             recovery_view()(pm1) =~= recovery_view()(pm2),
             perm.check_permission(pm1),
@@ -98,7 +98,7 @@ verus! {
     /// Proves that a PM region has the given header at the given position. Useful for
     /// associating a region with a header structure when the struct will be used later
     /// in a proof.
-    pub proof fn lemma_header_match(pm: Seq<u8>, header_pos: int, header: PersistentHeader)
+    proof fn lemma_header_match(pm: Seq<u8>, header_pos: int, header: PersistentHeader)
         requires
             pm.len() > contents_offset,
             header_pos == header1_pos || header_pos == header2_pos,
@@ -125,7 +125,7 @@ verus! {
 
     /// Proves that a given header structure consists of a CRC given in bytes as `crc_bytes` and a metadata structure
     /// given in bytes as `metadata_bytes`.
-    pub proof fn lemma_bytes_combine_into_header(crc_bytes: Seq<u8>, metadata_bytes: Seq<u8>, header: PersistentHeader)
+    proof fn lemma_bytes_combine_into_header(crc_bytes: Seq<u8>, metadata_bytes: Seq<u8>, header: PersistentHeader)
         requires
             crc_bytes.len() == 8,
             metadata_bytes.len() == header_size - 8,
@@ -148,7 +148,7 @@ verus! {
 
     /// Converse of lemma_bytes_combine_into_header; proves that the byte representation of a header consists of
     /// the byte representations of its CRC and metadata
-    pub proof fn lemma_header_split_into_bytes(crc_bytes: Seq<u8>, metadata_bytes: Seq<u8>, header_bytes: Seq<u8>)
+    proof fn lemma_header_split_into_bytes(crc_bytes: Seq<u8>, metadata_bytes: Seq<u8>, header_bytes: Seq<u8>)
         requires
             crc_bytes.len() == 8,
             metadata_bytes.len() == header_size - 8,
@@ -173,7 +173,7 @@ verus! {
 
     }
 
-    pub proof fn lemma_seq_addition(bytes1: Seq<u8>, bytes2: Seq<u8>)
+    proof fn lemma_seq_addition(bytes1: Seq<u8>, bytes2: Seq<u8>)
         ensures
             ({
                 let i = bytes1.len() as int;
@@ -330,7 +330,7 @@ verus! {
 
     /// Proves that two sequences of bytes (assumed to be the subrange of a persistent memory device containing
     /// the PersistentHeaderMetadata) are equivalent if their PersistentHeaderMetadata representations are equivalent
-    pub proof fn lemma_metadata_bytes_eq(bytes1: Seq<u8>, bytes2: Seq<u8>, metadata: PersistentHeaderMetadata)
+    proof fn lemma_metadata_bytes_eq(bytes1: Seq<u8>, bytes2: Seq<u8>, metadata: PersistentHeaderMetadata)
         requires
             bytes1.len() == header_size - 8,
             bytes2.len() == header_size - 8,
@@ -364,7 +364,7 @@ verus! {
                             bytes1.subrange(header_log_size_offset - 8, header_log_size_offset - 8 + 8));
     }
 
-    pub open spec(checked) fn spec_bytes_to_header(header_seq: Seq<u8>) -> PersistentHeader
+    spec(checked) fn spec_bytes_to_header(header_seq: Seq<u8>) -> PersistentHeader
         recommends
             header_seq.len() == header_size
     {
@@ -377,7 +377,7 @@ verus! {
     }
 
     /// Proves that a write to data that does not touch any metadata is crash safe.
-    pub proof fn lemma_data_write_is_safe<Perm>(pm: Seq<u8>, bytes: Seq<u8>, write_addr: int, perm: &Perm)
+    proof fn lemma_data_write_is_safe<Perm>(pm: Seq<u8>, bytes: Seq<u8>, write_addr: int, perm: &Perm)
         where
             Perm: CheckPermission<Seq<u8>>,
         requires
@@ -430,7 +430,7 @@ verus! {
         }
     }
 
-    pub open spec fn update_data_view_postcond(pm: Seq<u8>, new_bytes: Seq<u8>, write_addr: int) -> bool
+    spec fn update_data_view_postcond(pm: Seq<u8>, new_bytes: Seq<u8>, write_addr: int) -> bool
     {
         let new_pm = update_contents_to_reflect_write(pm, write_addr, new_bytes);
         let (old_ib, old_headers, old_data) = pm_to_views(pm);
@@ -456,7 +456,7 @@ verus! {
     }
 
     /// Proves that a non-crashing data write updates data bytes but no log metadata.
-    pub proof fn lemma_append_data_update_view(pm: Seq<u8>, new_bytes: Seq<u8>, write_addr: int)
+    proof fn lemma_append_data_update_view(pm: Seq<u8>, new_bytes: Seq<u8>, write_addr: int)
         requires
             UntrustedLogImpl::recover(pm) is Some,
             pm.len() > contents_offset,
@@ -496,7 +496,7 @@ verus! {
     }
 
     /// Proves that a crashing data write updates data bytes but no log metadata.
-    pub proof fn lemma_append_data_update_view_crash(pm: Seq<u8>, new_bytes: Seq<u8>, write_addr: int, chunks_flushed: Set<int>)
+    proof fn lemma_append_data_update_view_crash(pm: Seq<u8>, new_bytes: Seq<u8>, write_addr: int, chunks_flushed: Set<int>)
         requires
             UntrustedLogImpl::recover(pm) is Some,
             pm.len() > contents_offset,
@@ -535,7 +535,7 @@ verus! {
     }
 
     /// Proves that a non-crashing update to the inactive header does not change any visible PM state.
-    pub proof fn lemma_inactive_header_update_view(pm: Seq<u8>, new_header_bytes: Seq<u8>, header_pos: int)
+    proof fn lemma_inactive_header_update_view(pm: Seq<u8>, new_header_bytes: Seq<u8>, header_pos: int)
         requires
             UntrustedLogImpl::recover(pm) is Some,
             header_pos == header1_pos || header_pos == header2_pos,
@@ -582,7 +582,7 @@ verus! {
     }
 
     /// Proves that a crashing update to the inactive header does not change any visible PM state.
-    pub proof fn lemma_inactive_header_update_view_crash(pm: Seq<u8>, new_header_bytes: Seq<u8>, header_pos: int, chunks_flushed: Set<int>)
+    proof fn lemma_inactive_header_update_view_crash(pm: Seq<u8>, new_header_bytes: Seq<u8>, header_pos: int, chunks_flushed: Set<int>)
         requires
             UntrustedLogImpl::recover(pm) is Some,
             header_pos == header1_pos || header_pos == header2_pos,
@@ -853,7 +853,7 @@ verus! {
     /// Proves that an update to the incorruptible boolean is crash-safe and switches the log's
     /// active header. This lemma does most of the work to prove that untrusted_append is
     /// implemented correctly.
-    pub proof fn lemma_append_ib_update<Perm: CheckPermission<Seq<u8>>>(
+    proof fn lemma_append_ib_update<Perm: CheckPermission<Seq<u8>>>(
         pm: Seq<u8>,
         new_ib: u64,
         bytes_to_append: Seq<u8>,
@@ -940,7 +940,7 @@ verus! {
         lemma_single_write_crash(pm, incorruptible_bool_pos as int, ib_bytes);
     }
 
-    pub open spec fn live_data_view_eq(old_pm: Seq<u8>, new_pm: Seq<u8>) -> bool
+    spec fn live_data_view_eq(old_pm: Seq<u8>, new_pm: Seq<u8>) -> bool
     {
         let (old_ib, old_headers, old_data) = pm_to_views(old_pm);
         let (new_ib, new_headers, new_data) = pm_to_views(new_pm);
@@ -963,7 +963,7 @@ verus! {
                 physical_data_head == physical_data_tail
     }
 
-    pub proof fn lemma_same_log_state(old_pm: Seq<u8>, new_pm: Seq<u8>)
+    proof fn lemma_same_log_state(old_pm: Seq<u8>, new_pm: Seq<u8>)
         requires
             UntrustedLogImpl::recover(old_pm) is Some,
             UntrustedLogImpl::recover(new_pm) is Some,
@@ -1024,7 +1024,7 @@ verus! {
         }
     }
 
-    pub proof fn lemma_subrange_equality_implies_index_equality<T>(s1: Seq<T>, s2: Seq<T>, i: int, j: int)
+    proof fn lemma_subrange_equality_implies_index_equality<T>(s1: Seq<T>, s2: Seq<T>, i: int, j: int)
         requires
             0 <= i <= j <= s1.len(),
             j <= s2.len(),
@@ -1039,7 +1039,7 @@ verus! {
         }
     }
 
-    pub proof fn lemma_subrange_equality_implies_subsubrange_equality<T>(s1: Seq<T>, s2: Seq<T>, i: int, j: int)
+    proof fn lemma_subrange_equality_implies_subsubrange_equality<T>(s1: Seq<T>, s2: Seq<T>, i: int, j: int)
         requires
             0 <= i <= j <= s1.len(),
             j <= s2.len(),
@@ -1053,7 +1053,7 @@ verus! {
         }
     }
 
-    pub proof fn lemma_subrange_equality_implies_subsubrange_equality_forall<T>()
+    proof fn lemma_subrange_equality_implies_subsubrange_equality_forall<T>()
         ensures
             forall |s1: Seq<T>, s2: Seq<T>, i: int, j: int, k: int, m: int|
                 {
@@ -1076,7 +1076,7 @@ verus! {
         }
     }
 
-    pub proof fn lemma_headers_unchanged(old_pm: Seq<u8>, new_pm: Seq<u8>)
+    proof fn lemma_headers_unchanged(old_pm: Seq<u8>, new_pm: Seq<u8>)
         requires
             old_pm.len() == new_pm.len(),
             old_pm.len() >= contents_offset,
@@ -1092,7 +1092,7 @@ verus! {
         lemma_subrange_equality_implies_subsubrange_equality_forall::<u8>();
     }
 
-    pub proof fn lemma_incorruptible_bool_unchanged(old_pm: Seq<u8>, new_pm: Seq<u8>)
+    proof fn lemma_incorruptible_bool_unchanged(old_pm: Seq<u8>, new_pm: Seq<u8>)
         requires
             old_pm.len() == new_pm.len(),
             old_pm.len() >= contents_offset,
@@ -1105,7 +1105,7 @@ verus! {
             })
     {}
 
-    pub proof fn lemma_header_crc_correct(header_bytes: Seq<u8>, crc_bytes: Seq<u8>, metadata_bytes: Seq<u8>)
+    proof fn lemma_header_crc_correct(header_bytes: Seq<u8>, crc_bytes: Seq<u8>, metadata_bytes: Seq<u8>)
         requires
             header_bytes.len() == header_size,
             crc_bytes.len() == 8,
@@ -1122,7 +1122,7 @@ verus! {
         assert(header_bytes.subrange(header_head_offset as int, header_size as int) =~= metadata_bytes);
     }
 
-    pub proof fn lemma_header_correct(pm: Seq<u8>, header_bytes: Seq<u8>, header_pos: int)
+    proof fn lemma_header_correct(pm: Seq<u8>, header_bytes: Seq<u8>, header_pos: int)
         requires
             pm.len() > contents_offset,
             header_bytes.len() == header_size,
@@ -1144,14 +1144,14 @@ verus! {
             header_bytes.subrange(header_head_offset as int, header_size as int));
     }
 
-    pub proof fn lemma_u64_bytes_eq(val1: u64, val2: u64)
+    proof fn lemma_u64_bytes_eq(val1: u64, val2: u64)
         requires
             val1 == val2
         ensures
             spec_u64_to_le_bytes(val1) =~= spec_u64_to_le_bytes(val2)
     {}
 
-    pub proof fn lemma_subrange_eq<T>(bytes1: Seq<T>, bytes2: Seq<T>)
+    proof fn lemma_subrange_eq<T>(bytes1: Seq<T>, bytes2: Seq<T>)
         requires
             bytes1 =~= bytes2
         ensures
@@ -1160,7 +1160,7 @@ verus! {
 
     /// If our write is persistence_chunk_size-sized and -aligned, then there are only 2 possible
     /// resulting crash states, one with the write and one without.
-    pub proof fn lemma_single_write_crash(pm: Seq<u8>, write_addr: int, bytes_to_write: Seq<u8>)
+    proof fn lemma_single_write_crash(pm: Seq<u8>, write_addr: int, bytes_to_write: Seq<u8>)
         requires
             bytes_to_write.len() == persistence_chunk_size,
             write_addr % persistence_chunk_size == 0, // currently seems to succeed without nonlinear arith
@@ -1177,7 +1177,7 @@ verus! {
             })
     {}
 
-    pub proof fn lemma_pm_state_header(pm: Seq<u8>)
+    proof fn lemma_pm_state_header(pm: Seq<u8>)
         requires
             UntrustedLogImpl::recover(pm) is Some,
             ({
@@ -1243,7 +1243,7 @@ verus! {
 
     impl UntrustedLogImpl {
 
-        pub exec fn addr_logical_to_physical(addr: u64, log_size: u64) -> (out: u64)
+        exec fn addr_logical_to_physical(addr: u64, log_size: u64) -> (out: u64)
             requires
                 addr <= u64::MAX,
                 log_size > 0,
@@ -1343,7 +1343,7 @@ verus! {
                }
         }
 
-        pub proof fn lemma_complete_inv_pm_contents(&self, contents: Seq<u8>)
+        proof fn lemma_complete_inv_pm_contents(&self, contents: Seq<u8>)
             requires
                 Self::recover(contents) is Some,
                 ({
@@ -1383,7 +1383,7 @@ verus! {
             &&& self.inv_pm_contents(wrpm@)
         }
 
-        pub exec fn read_incorruptible_boolean<PM: PersistentMemory>(pm: &PM) -> (result: Result<u64, InfiniteLogErr>)
+        exec fn read_incorruptible_boolean<PM: PersistentMemory>(pm: &PM) -> (result: Result<u64, InfiniteLogErr>)
             requires
                 Self::recover(pm@) is Some,
                 pm.inv(),
@@ -1887,7 +1887,7 @@ verus! {
             }
         }
 
-        pub exec fn append_wrap<Perm, PM>(
+        exec fn append_wrap<Perm, PM>(
             &mut self,
             wrpm: &mut WriteRestrictedPersistentMemory<Perm, PM>,
             bytes_to_append: &Vec<u8>,

--- a/pmemlog/src/logimpl_v.rs
+++ b/pmemlog/src/logimpl_v.rs
@@ -629,6 +629,7 @@ verus! {
         }
     }
 
+    #[verifier::rlimit(20)]
     pub proof fn lemma_append_ib_update_effect_on_committed<Perm: CheckPermission<Seq<u8>>>(
         pm: Seq<u8>,
         new_ib: u64,

--- a/unverified/metadata_kv/Cargo.lock
+++ b/unverified/metadata_kv/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,12 +134,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -158,16 +158,6 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -266,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -513,14 +503,17 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2026-05-17-0151"
-source = "git+https://github.com/verus-lang/verus.git#bdaaf5793bf445b3242adeb0d55423c7eab9fe10"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27a0e580576f364e98925a61618089591e5bdea6e1ccf048b1d56ab3dfada70"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-05-31-0205"
-source = "git+https://github.com/verus-lang/verus.git#bdaaf5793bf445b3242adeb0d55423c7eab9fe10"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabf0883a6e62f1db1538f96607e500dd396ada513329c3f486a14de5611d55b"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -531,8 +524,9 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2026-05-31-0205"
-source = "git+https://github.com/verus-lang/verus.git#bdaaf5793bf445b3242adeb0d55423c7eab9fe10"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88628e583fb019eac36690ca2500b158f0221df6be2bae1e7c2a35dd6536bfc"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -540,10 +534,11 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2026-05-31-0205"
-source = "git+https://github.com/verus-lang/verus.git#bdaaf5793bf445b3242adeb0d55423c7eab9fe10"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f77ff8d121edb1bf2651335769a80a2f611da8573c3b498434a66b3162805f"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
  "proc-macro2",
  "quote",
  "verus_syn",
@@ -551,8 +546,9 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2026-05-31-0205"
-source = "git+https://github.com/verus-lang/verus.git#bdaaf5793bf445b3242adeb0d55423c7eab9fe10"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17237ea6d267e457d53ce36f55b315fc9edd26eb88c765dd95e035c0b415869"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -561,8 +557,9 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-05-31-0205"
-source = "git+https://github.com/verus-lang/verus.git#bdaaf5793bf445b3242adeb0d55423c7eab9fe10"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25040241d96eb88dfc6a75c289dc0ef84845ffff051d8e595cc55908d5c06a45"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",
@@ -619,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -632,7 +629,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.4.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -802,7 +799,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -833,7 +830,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -852,7 +849,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/unverified/metadata_kv/Cargo.toml
+++ b/unverified/metadata_kv/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 # Avoid default features since @lopopolo reports that rand is unsound with both the log and thread_rng features
 rand = { version = "0.10.1", default-features = false, features = [ "thread_rng" ] }
-vstd = { git = "https://github.com/verus-lang/verus.git" }
+vstd = { version = "=0.0.0-2026-08-02-0125" }
 proptest = "1.4"


### PR DESCRIPTION
This PR makes the projects verify with the latest version of Verus. The most notable change that's happened recently is the switch to a new version of Z3.